### PR TITLE
Use a single secret value to identify clients

### DIFF
--- a/cli/src/invocation/mod.rs
+++ b/cli/src/invocation/mod.rs
@@ -108,20 +108,20 @@ fn get_replica(settings: &Config) -> Fallible<Replica> {
 fn get_server(settings: &Config) -> Fallible<Box<dyn server::Server>> {
     // if server_client_id and server_origin are both set, use
     // the remote server
-    if let (Ok(client_id), Ok(origin)) = (
+    if let (Ok(client_key), Ok(origin)) = (
         settings.get_str("server_client_id"),
         settings.get_str("server_origin"),
     ) {
-        let client_id = Uuid::parse_str(&client_id)?;
+        let client_key = Uuid::parse_str(&client_key)?;
         let encryption_secret = settings
             .get_str("encryption_secret")
             .map_err(|_| format_err!("Could not read `encryption_secret` configuration"))?;
 
         log::debug!("Using sync-server with origin {}", origin);
-        log::debug!("Sync client ID: {}", client_id);
+        log::debug!("Sync client ID: {}", client_key);
         Ok(server::from_config(ServerConfig::Remote {
             origin,
-            client_id,
+            client_key,
             encryption_secret: encryption_secret.as_bytes().to_vec(),
         })?)
     } else {

--- a/docs/src/sync-protocol.md
+++ b/docs/src/sync-protocol.md
@@ -69,10 +69,11 @@ The transactions above are realized for an HTTP server at `<origin>` using the H
 The `origin` *should* be an HTTPS endpoint on general principle, but nothing in the functonality or security of the protocol depends on connection encryption.
 
 The replica identifies itself to the server using a `clientKey` in the form of a UUID.
+This value is passed with every request in the `X-Client-Id` header, in its dashed-hex format.
 
 ### AddVersion
 
-The request is a `POST` to `<origin>/client/<clientId>/add-version/<parentVersionId>`.
+The request is a `POST` to `<origin>/client/add-version/<parentVersionId>`.
 The request body contains the history segment, optionally encoded using any encoding supported by actix-web.
 The content-type must be `application/vnd.taskchampion.history-segment`.
 
@@ -86,7 +87,7 @@ Other error responses (4xx or 5xx) may be returned and should be treated appropr
 
 ### GetChildVersion
 
-The request is a `GET` to `<origin>/client/<clientId>/get-child-version/<parentVersionId>`.
+The request is a `GET` to `<origin>/client/get-child-version/<parentVersionId>`.
 The response is 404 NOT FOUND if no such version exists.
 Otherwise, the response is a 200 OK.
 The version's history segment is returned in the response body, with content-type `application/vnd.taskchampion.history-segment`.

--- a/docs/src/sync-protocol.md
+++ b/docs/src/sync-protocol.md
@@ -9,6 +9,8 @@ The protocol builds on the model presented in the previous chapter, and in parti
 
 From the server's perspective, replicas are indistinguishable, so this protocol uses the term "client" to refer generically to all replicas replicating a single task history.
 
+Each client is identified and authenticated with a "client key", known only to the server and to the replicas replicating the task history.
+
 ## Server
 
 For each client, the server is responsible for storing the task history, in the form of a branch-free sequence of versions.
@@ -66,7 +68,7 @@ If not found, the server returns a negative response.
 The transactions above are realized for an HTTP server at `<origin>` using the HTTP requests and responses described here.
 The `origin` *should* be an HTTPS endpoint on general principle, but nothing in the functonality or security of the protocol depends on connection encryption.
 
-The replica identifies itself to the server using a `clientId` in the form of a UUID.
+The replica identifies itself to the server using a `clientKey` in the form of a UUID.
 
 ### AddVersion
 

--- a/sync-server/src/api/mod.rs
+++ b/sync-server/src/api/mod.rs
@@ -1,5 +1,6 @@
+use crate::server::ClientKey;
 use crate::storage::Storage;
-use actix_web::{error, http::StatusCode, web, Scope};
+use actix_web::{error, http::StatusCode, web, HttpRequest, Result, Scope};
 use std::sync::Arc;
 
 mod add_version;
@@ -9,10 +10,13 @@ mod get_child_version;
 pub(crate) const HISTORY_SEGMENT_CONTENT_TYPE: &str =
     "application/vnd.taskchampion.history-segment";
 
-/// The header names for version ID
+/// The header name for version ID
 pub(crate) const VERSION_ID_HEADER: &str = "X-Version-Id";
 
-/// The header names for parent version ID
+/// The header name for client key
+pub(crate) const CLIENT_KEY_HEADER: &str = "X-Client-Key";
+
+/// The header name for parent version ID
 pub(crate) const PARENT_VERSION_ID_HEADER: &str = "X-Parent-Version-Id";
 
 /// The type containing a reference to the Storage object in the Actix state.
@@ -27,4 +31,18 @@ pub(crate) fn api_scope() -> Scope {
 /// Convert a failure::Error to an Actix ISE
 fn failure_to_ise(err: failure::Error) -> impl actix_web::ResponseError {
     error::InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Get the client key
+fn client_key_header(req: &HttpRequest) -> Result<ClientKey> {
+    fn badrequest() -> error::Error {
+        error::ErrorBadRequest("bad x-client-id")
+    }
+    if let Some(client_key_hdr) = req.headers().get(CLIENT_KEY_HEADER) {
+        let client_key = client_key_hdr.to_str().map_err(|_| badrequest())?;
+        let client_key = ClientKey::parse_str(client_key).map_err(|_| badrequest())?;
+        Ok(client_key)
+    } else {
+        Err(badrequest())
+    }
 }

--- a/sync-server/src/storage/kv.rs
+++ b/sync-server/src/storage/kv.rs
@@ -4,28 +4,28 @@ use kv::msgpack::Msgpack;
 use kv::{Bucket, Config, Error, Serde, Store, ValueBuf};
 use std::path::Path;
 
-/// Key for versions: concatenation of client_id and parent_version_id
-type VersionKey = [u8; 32];
+/// DB Key for versions: concatenation of client_key and parent_version_id
+type VersionDbKey = [u8; 32];
 
-fn version_key(client_id: Uuid, parent_version_id: Uuid) -> VersionKey {
+fn version_db_key(client_key: Uuid, parent_version_id: Uuid) -> VersionDbKey {
     let mut key = [0u8; 32];
-    key[..16].clone_from_slice(client_id.as_bytes());
+    key[..16].clone_from_slice(client_key.as_bytes());
     key[16..].clone_from_slice(parent_version_id.as_bytes());
     key
 }
 
-/// Key for clients: just the client_id
-type ClientKey = [u8; 16];
+/// Key for clients: just the client_key
+type ClientDbKey = [u8; 16];
 
-fn client_key(client_id: Uuid) -> ClientKey {
-    *client_id.as_bytes()
+fn client_db_key(client_key: Uuid) -> ClientDbKey {
+    *client_key.as_bytes()
 }
 
 /// KVStorage is an on-disk storage backend which uses LMDB via the `kv` crate.
 pub(crate) struct KVStorage<'t> {
     store: Store,
-    clients_bucket: Bucket<'t, ClientKey, ValueBuf<Msgpack<Client>>>,
-    versions_bucket: Bucket<'t, VersionKey, ValueBuf<Msgpack<Version>>>,
+    clients_bucket: Bucket<'t, ClientDbKey, ValueBuf<Msgpack<Client>>>,
+    versions_bucket: Bucket<'t, VersionDbKey, ValueBuf<Msgpack<Version>>>,
 }
 
 impl<'t> KVStorage<'t> {
@@ -37,9 +37,9 @@ impl<'t> KVStorage<'t> {
         let store = Store::new(config)?;
 
         let clients_bucket =
-            store.bucket::<ClientKey, ValueBuf<Msgpack<Client>>>(Some("clients"))?;
+            store.bucket::<ClientDbKey, ValueBuf<Msgpack<Client>>>(Some("clients"))?;
         let versions_bucket =
-            store.bucket::<VersionKey, ValueBuf<Msgpack<Version>>>(Some("versions"))?;
+            store.bucket::<VersionDbKey, ValueBuf<Msgpack<Version>>>(Some("versions"))?;
 
         Ok(KVStorage {
             store,
@@ -73,17 +73,17 @@ impl<'t> Txn<'t> {
         }
     }
 
-    fn clients_bucket(&self) -> &'t Bucket<'t, ClientKey, ValueBuf<Msgpack<Client>>> {
+    fn clients_bucket(&self) -> &'t Bucket<'t, ClientDbKey, ValueBuf<Msgpack<Client>>> {
         &self.storage.clients_bucket
     }
-    fn versions_bucket(&self) -> &'t Bucket<'t, VersionKey, ValueBuf<Msgpack<Version>>> {
+    fn versions_bucket(&self) -> &'t Bucket<'t, VersionDbKey, ValueBuf<Msgpack<Version>>> {
         &self.storage.versions_bucket
     }
 }
 
 impl<'t> StorageTxn for Txn<'t> {
-    fn get_client(&mut self, client_id: Uuid) -> Fallible<Option<Client>> {
-        let key = client_key(client_id);
+    fn get_client(&mut self, client_key: Uuid) -> Fallible<Option<Client>> {
+        let key = client_db_key(client_key);
         let bucket = self.clients_bucket();
         let kvtxn = self.kvtxn();
 
@@ -97,8 +97,8 @@ impl<'t> StorageTxn for Txn<'t> {
         Ok(Some(client))
     }
 
-    fn new_client(&mut self, client_id: Uuid, latest_version_id: Uuid) -> Fallible<()> {
-        let key = client_key(client_id);
+    fn new_client(&mut self, client_key: Uuid, latest_version_id: Uuid) -> Fallible<()> {
+        let key = client_db_key(client_key);
         let bucket = self.clients_bucket();
         let kvtxn = self.kvtxn();
         let client = Client { latest_version_id };
@@ -108,19 +108,19 @@ impl<'t> StorageTxn for Txn<'t> {
 
     fn set_client_latest_version_id(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         latest_version_id: Uuid,
     ) -> Fallible<()> {
         // implementation is the same as new_client..
-        self.new_client(client_id, latest_version_id)
+        self.new_client(client_key, latest_version_id)
     }
 
     fn get_version_by_parent(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         parent_version_id: Uuid,
     ) -> Fallible<Option<Version>> {
-        let key = version_key(client_id, parent_version_id);
+        let key = version_db_key(client_key, parent_version_id);
         let bucket = self.versions_bucket();
         let kvtxn = self.kvtxn();
         let version = match kvtxn.get(&bucket, key) {
@@ -135,12 +135,12 @@ impl<'t> StorageTxn for Txn<'t> {
 
     fn add_version(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         version_id: Uuid,
         parent_version_id: Uuid,
         history_segment: Vec<u8>,
     ) -> Fallible<()> {
-        let key = version_key(client_id, parent_version_id);
+        let key = version_db_key(client_key, parent_version_id);
         let bucket = self.versions_bucket();
         let kvtxn = self.kvtxn();
         let version = Version {
@@ -184,17 +184,17 @@ mod test {
         let storage = KVStorage::new(&tmp_dir.path())?;
         let mut txn = storage.txn()?;
 
-        let client_id = Uuid::new_v4();
+        let client_key = Uuid::new_v4();
         let latest_version_id = Uuid::new_v4();
-        txn.new_client(client_id, latest_version_id)?;
+        txn.new_client(client_key, latest_version_id)?;
 
-        let client = txn.get_client(client_id)?.unwrap();
+        let client = txn.get_client(client_key)?.unwrap();
         assert_eq!(client.latest_version_id, latest_version_id);
 
         let latest_version_id = Uuid::new_v4();
-        txn.set_client_latest_version_id(client_id, latest_version_id)?;
+        txn.set_client_latest_version_id(client_key, latest_version_id)?;
 
-        let client = txn.get_client(client_id)?.unwrap();
+        let client = txn.get_client(client_key)?.unwrap();
         assert_eq!(client.latest_version_id, latest_version_id);
 
         Ok(())
@@ -216,18 +216,18 @@ mod test {
         let storage = KVStorage::new(&tmp_dir.path())?;
         let mut txn = storage.txn()?;
 
-        let client_id = Uuid::new_v4();
+        let client_key = Uuid::new_v4();
         let version_id = Uuid::new_v4();
         let parent_version_id = Uuid::new_v4();
         let history_segment = b"abc".to_vec();
         txn.add_version(
-            client_id,
+            client_key,
             version_id,
             parent_version_id,
             history_segment.clone(),
         )?;
         let version = txn
-            .get_version_by_parent(client_id, parent_version_id)?
+            .get_version_by_parent(client_key, parent_version_id)?
             .unwrap();
 
         assert_eq!(

--- a/sync-server/src/storage/mod.rs
+++ b/sync-server/src/storage/mod.rs
@@ -24,29 +24,29 @@ pub(crate) struct Version {
 
 pub(crate) trait StorageTxn {
     /// Get information about the given client
-    fn get_client(&mut self, client_id: Uuid) -> Fallible<Option<Client>>;
+    fn get_client(&mut self, client_key: Uuid) -> Fallible<Option<Client>>;
 
     /// Create a new client with the given latest_version_id
-    fn new_client(&mut self, client_id: Uuid, latest_version_id: Uuid) -> Fallible<()>;
+    fn new_client(&mut self, client_key: Uuid, latest_version_id: Uuid) -> Fallible<()>;
 
     /// Set the client's latest_version_id
     fn set_client_latest_version_id(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         latest_version_id: Uuid,
     ) -> Fallible<()>;
 
     /// Get a version, indexed by parent version id
     fn get_version_by_parent(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         parent_version_id: Uuid,
     ) -> Fallible<Option<Version>>;
 
     /// Add a version (that must not already exist)
     fn add_version(
         &mut self,
-        client_id: Uuid,
+        client_key: Uuid,
         version_id: Uuid,
         parent_version_id: Uuid,
         history_segment: Vec<u8>,

--- a/taskchampion/src/config.rs
+++ b/taskchampion/src/config.rs
@@ -20,8 +20,8 @@ pub enum ServerConfig {
         /// Sync server "origin"; a URL with schema and hostname but no path or trailing `/`
         origin: String,
 
-        /// Client ID to identify this replica to the server
-        client_id: Uuid,
+        /// Client Key to identify and authenticate this replica to the server
+        client_key: Uuid,
 
         /// Private encryption secret used to encrypt all data sent to the server.  This can
         /// be any suitably un-guessable string of bytes.

--- a/taskchampion/src/server/mod.rs
+++ b/taskchampion/src/server/mod.rs
@@ -18,8 +18,8 @@ pub fn from_config(config: ServerConfig) -> Fallible<Box<dyn Server>> {
         ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
         ServerConfig::Remote {
             origin,
-            client_id,
+            client_key,
             encryption_secret,
-        } => Box::new(RemoteServer::new(origin, client_id, encryption_secret)),
+        } => Box::new(RemoteServer::new(origin, client_key, encryption_secret)),
     })
 }

--- a/taskchampion/src/server/remote/mod.rs
+++ b/taskchampion/src/server/remote/mod.rs
@@ -8,7 +8,7 @@ use crypto::{HistoryCiphertext, HistoryCleartext, Secret};
 
 pub struct RemoteServer {
     origin: String,
-    client_id: Uuid,
+    client_key: Uuid,
     encryption_secret: Secret,
     agent: ureq::Agent,
 }
@@ -17,13 +17,13 @@ pub struct RemoteServer {
 /// taskchampion-sync-server).
 impl RemoteServer {
     /// Construct a new RemoteServer.  The `origin` is the sync server's protocol and hostname
-    /// without a trailing slash, such as `https://tcsync.example.com`.  Pass a client_id to
+    /// without a trailing slash, such as `https://tcsync.example.com`.  Pass a client_key to
     /// identify this client to the server.  Multiple replicas synchronizing the same task history
-    /// should use the same client_id.
-    pub fn new(origin: String, client_id: Uuid, encryption_secret: Vec<u8>) -> RemoteServer {
+    /// should use the same client_key.
+    pub fn new(origin: String, client_key: Uuid, encryption_secret: Vec<u8>) -> RemoteServer {
         RemoteServer {
             origin,
-            client_id,
+            client_key,
             encryption_secret: encryption_secret.into(),
             agent: ureq::agent(),
         }
@@ -58,7 +58,7 @@ impl Server for RemoteServer {
     ) -> Fallible<AddVersionResult> {
         let url = format!(
             "{}/client/{}/add-version/{}",
-            self.origin, self.client_id, parent_version_id
+            self.origin, self.client_key, parent_version_id
         );
         let history_cleartext = HistoryCleartext {
             parent_version_id,
@@ -89,7 +89,7 @@ impl Server for RemoteServer {
     fn get_child_version(&mut self, parent_version_id: VersionId) -> Fallible<GetVersionResult> {
         let url = format!(
             "{}/client/{}/get-child-version/{}",
-            self.origin, self.client_id, parent_version_id
+            self.origin, self.client_key, parent_version_id
         );
         let resp = self
             .agent


### PR DESCRIPTION
This works more like an API key than a userid.  So, let's not keep it in the URL.

Fixes #60.