### PR TITLE
Use named reports

### DIFF
--- a/cli/src/argparse/args.rs
+++ b/cli/src/argparse/args.rs
@@ -30,6 +30,11 @@ pub(super) fn any(input: &str) -> IResult<&str, &str> {
     rest(input)
 }
 
+/// Recognizes a report name
+pub(super) fn report_name(input: &str) -> IResult<&str, &str> {
+    all_consuming(recognize(pair(alpha1, alphanumeric0)))(input)
+}
+
 /// Recognizes a literal string
 pub(super) fn literal(literal: &'static str) -> impl Fn(&str) -> IResult<&str, &str> {
     move |input: &str| all_consuming(nomtag(literal))(input)

--- a/cli/src/argparse/args.rs
+++ b/cli/src/argparse/args.rs
@@ -10,7 +10,7 @@ use nom::{
     sequence::*,
     Err, IResult,
 };
-use taskchampion::Uuid;
+use taskchampion::{Status, Uuid};
 
 /// A task identifier, as given in a filter command-line expression
 #[derive(Debug, PartialEq, Clone)]
@@ -38,6 +38,32 @@ pub(super) fn report_name(input: &str) -> IResult<&str, &str> {
 /// Recognizes a literal string
 pub(super) fn literal(literal: &'static str) -> impl Fn(&str) -> IResult<&str, &str> {
     move |input: &str| all_consuming(nomtag(literal))(input)
+}
+
+/// Recognizes a colon-prefixed pair
+pub(super) fn colon_prefixed(prefix: &'static str) -> impl Fn(&str) -> IResult<&str, &str> {
+    fn to_suffix<'a>(input: (&'a str, char, &'a str)) -> Result<&'a str, ()> {
+        Ok(input.2)
+    }
+    move |input: &str| {
+        map_res(
+            all_consuming(tuple((nomtag(prefix), char(':'), any))),
+            to_suffix,
+        )(input)
+    }
+}
+
+/// Recognizes `status:{pending,completed,deleted}`
+pub(super) fn status_colon(input: &str) -> IResult<&str, Status> {
+    fn to_status(input: &str) -> Result<Status, ()> {
+        match input {
+            "pending" => Ok(Status::Pending),
+            "completed" => Ok(Status::Completed),
+            "deleted" => Ok(Status::Deleted),
+            _ => Err(()),
+        }
+    }
+    map_res(colon_prefixed("status"), to_status)(input)
 }
 
 /// Recognizes a comma-separated list of TaskIds
@@ -162,6 +188,26 @@ mod test {
             (argv!["bar"], "foo")
         );
         assert!(arg_matching(plus_tag)(argv!["foo", "bar"]).is_err());
+    }
+
+    #[test]
+    fn test_colon_prefixed() {
+        assert_eq!(colon_prefixed("foo")("foo:abc").unwrap().1, "abc");
+        assert_eq!(colon_prefixed("foo")("foo:").unwrap().1, "");
+        assert!(colon_prefixed("foo")("foo").is_err());
+    }
+
+    #[test]
+    fn test_status_colon() {
+        assert_eq!(status_colon("status:pending").unwrap().1, Status::Pending);
+        assert_eq!(
+            status_colon("status:completed").unwrap().1,
+            Status::Completed
+        );
+        assert_eq!(status_colon("status:deleted").unwrap().1, Status::Deleted);
+        assert!(status_colon("status:foo").is_err());
+        assert!(status_colon("status:complete").is_err());
+        assert!(status_colon("status").is_err());
     }
 
     #[test]

--- a/cli/src/argparse/mod.rs
+++ b/cli/src/argparse/mod.rs
@@ -19,7 +19,7 @@ mod subcommand;
 
 pub(crate) use args::TaskId;
 pub(crate) use command::Command;
-pub(crate) use filter::{Condition, Filter, Universe};
+pub(crate) use filter::{Condition, Filter};
 pub(crate) use modification::{DescriptionMod, Modification};
 pub(crate) use subcommand::Subcommand;
 

--- a/cli/src/argparse/mod.rs
+++ b/cli/src/argparse/mod.rs
@@ -15,14 +15,12 @@ mod args;
 mod command;
 mod filter;
 mod modification;
-mod report;
 mod subcommand;
 
 pub(crate) use args::TaskId;
 pub(crate) use command::Command;
 pub(crate) use filter::{Condition, Filter, Universe};
 pub(crate) use modification::{DescriptionMod, Modification};
-pub(crate) use report::{Column, Property, Report, Sort, SortBy};
 pub(crate) use subcommand::Subcommand;
 
 use crate::usage::Usage;

--- a/cli/src/argparse/subcommand.rs
+++ b/cli/src/argparse/subcommand.rs
@@ -383,7 +383,7 @@ impl Sync {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::argparse::Universe;
+    use crate::argparse::Condition;
 
     const EMPTY: Vec<&str> = vec![];
 
@@ -459,8 +459,7 @@ mod test {
     fn test_modify_description_multi() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 description: DescriptionMod::Set(s!("foo bar")),
@@ -477,8 +476,7 @@ mod test {
     fn test_append() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 description: DescriptionMod::Append(s!("foo bar")),
@@ -495,8 +493,7 @@ mod test {
     fn test_prepend() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 description: DescriptionMod::Prepend(s!("foo bar")),
@@ -513,8 +510,7 @@ mod test {
     fn test_done() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 status: Some(Status::Completed),
@@ -531,8 +527,7 @@ mod test {
     fn test_done_modify() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 description: DescriptionMod::Set(s!("now-finished")),
@@ -550,8 +545,7 @@ mod test {
     fn test_start() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 active: Some(true),
@@ -568,8 +562,7 @@ mod test {
     fn test_start_modify() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 active: Some(true),
@@ -587,8 +580,7 @@ mod test {
     fn test_stop() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 active: Some(false),
@@ -605,8 +597,7 @@ mod test {
     fn test_stop_modify() {
         let subcommand = Subcommand::Modify {
             filter: Filter {
-                universe: Universe::for_ids(vec![123]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
             },
             modification: Modification {
                 description: DescriptionMod::Set(s!("mod")),
@@ -636,8 +627,10 @@ mod test {
     fn test_report_filter_before() {
         let subcommand = Subcommand::Report {
             filter: Filter {
-                universe: Universe::for_ids(vec![12, 13]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![
+                    TaskId::WorkingSetId(12),
+                    TaskId::WorkingSetId(13),
+                ])],
             },
             report_name: "foo".to_owned(),
         };
@@ -651,8 +644,10 @@ mod test {
     fn test_report_filter_after() {
         let subcommand = Subcommand::Report {
             filter: Filter {
-                universe: Universe::for_ids(vec![12, 13]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![
+                    TaskId::WorkingSetId(12),
+                    TaskId::WorkingSetId(13),
+                ])],
             },
             report_name: "foo".to_owned(),
         };
@@ -666,8 +661,10 @@ mod test {
     fn test_report_filter_next() {
         let subcommand = Subcommand::Report {
             filter: Filter {
-                universe: Universe::for_ids(vec![12, 13]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![
+                    TaskId::WorkingSetId(12),
+                    TaskId::WorkingSetId(13),
+                ])],
             },
             report_name: "next".to_owned(),
         };
@@ -696,8 +693,10 @@ mod test {
         let subcommand = Subcommand::Info {
             debug: false,
             filter: Filter {
-                universe: Universe::for_ids(vec![12, 13]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![
+                    TaskId::WorkingSetId(12),
+                    TaskId::WorkingSetId(13),
+                ])],
             },
         };
         assert_eq!(
@@ -711,8 +710,7 @@ mod test {
         let subcommand = Subcommand::Info {
             debug: true,
             filter: Filter {
-                universe: Universe::for_ids(vec![12]),
-                ..Default::default()
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(12)])],
             },
         };
         assert_eq!(

--- a/cli/src/invocation/cmd/mod.rs
+++ b/cli/src/invocation/cmd/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod add;
 pub(crate) mod gc;
 pub(crate) mod help;
 pub(crate) mod info;
-pub(crate) mod list;
 pub(crate) mod modify;
+pub(crate) mod report;
 pub(crate) mod sync;
 pub(crate) mod version;

--- a/cli/src/invocation/cmd/report.rs
+++ b/cli/src/invocation/cmd/report.rs
@@ -1,4 +1,4 @@
-use crate::argparse::Report;
+use crate::argparse::Filter;
 use crate::invocation::display_report;
 use failure::Fallible;
 use taskchampion::Replica;
@@ -7,35 +7,33 @@ use termcolor::WriteColor;
 pub(crate) fn execute<W: WriteColor>(
     w: &mut W,
     replica: &mut Replica,
-    report: Report,
+    report_name: String,
+    filter: Filter,
 ) -> Fallible<()> {
-    display_report(w, replica, &report)
+    display_report(w, replica, report_name, filter)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::argparse::{Column, Filter, Property};
+    use crate::argparse::Filter;
     use crate::invocation::test::*;
     use taskchampion::Status;
 
     #[test]
-    fn test_list() {
+    fn test_report() {
         let mut w = test_writer();
         let mut replica = test_replica();
         replica.new_task(Status::Pending, s!("my task")).unwrap();
 
-        let report = Report {
-            filter: Filter {
-                ..Default::default()
-            },
-            columns: vec![Column {
-                label: "Description".to_owned(),
-                property: Property::Description,
-            }],
+        // The function being tested is only one line long, so this is sort of an integration test
+        // for display_report.
+
+        let report_name = "next".to_owned();
+        let filter = Filter {
             ..Default::default()
         };
-        execute(&mut w, &mut replica, report).unwrap();
+        execute(&mut w, &mut replica, report_name, filter).unwrap();
         assert!(w.into_string().contains("my task"));
     }
 }

--- a/cli/src/invocation/mod.rs
+++ b/cli/src/invocation/mod.rs
@@ -60,9 +60,13 @@ pub(crate) fn invoke(command: Command, settings: Config) -> Fallible<()> {
         } => return cmd::modify::execute(&mut w, &mut replica, filter, modification),
 
         Command {
-            subcommand: Subcommand::List { report },
+            subcommand:
+                Subcommand::Report {
+                    report_name,
+                    filter,
+                },
             ..
-        } => return cmd::list::execute(&mut w, &mut replica, report),
+        } => return cmd::report::execute(&mut w, &mut replica, report_name, filter),
 
         Command {
             subcommand: Subcommand::Info { filter, debug },

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -38,6 +38,7 @@ mod macros;
 
 mod argparse;
 mod invocation;
+mod report;
 mod settings;
 mod table;
 mod usage;

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,4 +1,6 @@
-use super::Filter;
+//! This module contains the data structures used to define reports.
+
+use crate::argparse::Filter;
 
 /// A report specifies a filter as well as a sort order and information about which
 /// task attributes to display


### PR DESCRIPTION
This substantially refactors filtering, too.  It was a one-thing-leads-to-another situation: 
 * named reports have filters, and users can give additional filter command-line arguments, so we need a way to combine those
 * combining filters with universes is hard, so let's limit the scope of universes
 * now we have more conditions, so let's make command-line syntax for them (well, we already have syntax for Condition::IdList..)

I'll file a few followups.