### PR TITLE
Automatically add new pending tasks to working set after sync

### DIFF
--- a/cli/src/invocation/cmd/gc.rs
+++ b/cli/src/invocation/cmd/gc.rs
@@ -4,7 +4,7 @@ use termcolor::WriteColor;
 
 pub(crate) fn execute<W: WriteColor>(w: &mut W, replica: &mut Replica) -> Fallible<()> {
     log::debug!("rebuilding working set");
-    replica.rebuild_working_set()?;
+    replica.rebuild_working_set(true)?;
     writeln!(w, "garbage collected.")?;
     Ok(())
 }

--- a/cli/src/invocation/cmd/gc.rs
+++ b/cli/src/invocation/cmd/gc.rs
@@ -3,7 +3,8 @@ use taskchampion::Replica;
 use termcolor::WriteColor;
 
 pub(crate) fn execute<W: WriteColor>(w: &mut W, replica: &mut Replica) -> Fallible<()> {
-    replica.gc()?;
+    log::debug!("rebuilding working set");
+    replica.rebuild_working_set()?;
     writeln!(w, "garbage collected.")?;
     Ok(())
 }

--- a/cli/src/invocation/filter.rs
+++ b/cli/src/invocation/filter.rs
@@ -184,7 +184,7 @@ mod test {
         let t1 = replica.new_task(Status::Pending, s!("A")).unwrap();
         let t2 = replica.new_task(Status::Completed, s!("B")).unwrap();
         let _t = replica.new_task(Status::Pending, s!("C")).unwrap();
-        replica.rebuild_working_set().unwrap();
+        replica.rebuild_working_set(true).unwrap();
 
         let t1uuid = *t1.get_uuid();
 
@@ -210,7 +210,7 @@ mod test {
         let t1 = replica.new_task(Status::Pending, s!("A")).unwrap();
         let t2 = replica.new_task(Status::Completed, s!("B")).unwrap();
         let _t = replica.new_task(Status::Pending, s!("C")).unwrap();
-        replica.rebuild_working_set().unwrap();
+        replica.rebuild_working_set(true).unwrap();
 
         let t1uuid = *t1.get_uuid();
         let t2uuid = t2.get_uuid().to_string();
@@ -238,7 +238,7 @@ mod test {
         replica.new_task(Status::Pending, s!("A")).unwrap();
         replica.new_task(Status::Completed, s!("B")).unwrap();
         replica.new_task(Status::Deleted, s!("C")).unwrap();
-        replica.rebuild_working_set().unwrap();
+        replica.rebuild_working_set(true).unwrap();
 
         let filter = Filter { conditions: vec![] };
         let mut filtered: Vec<_> = filtered_tasks(&mut replica, &filter)
@@ -309,7 +309,7 @@ mod test {
         replica.new_task(Status::Pending, s!("A")).unwrap();
         replica.new_task(Status::Completed, s!("B")).unwrap();
         replica.new_task(Status::Deleted, s!("C")).unwrap();
-        replica.rebuild_working_set().unwrap();
+        replica.rebuild_working_set(true).unwrap();
 
         let filter = Filter {
             conditions: vec![Condition::Status(Status::Pending)],

--- a/cli/src/invocation/filter.rs
+++ b/cli/src/invocation/filter.rs
@@ -184,7 +184,7 @@ mod test {
         let t1 = replica.new_task(Status::Pending, s!("A")).unwrap();
         let t2 = replica.new_task(Status::Completed, s!("B")).unwrap();
         let _t = replica.new_task(Status::Pending, s!("C")).unwrap();
-        replica.gc().unwrap();
+        replica.rebuild_working_set().unwrap();
 
         let t1uuid = *t1.get_uuid();
 
@@ -210,7 +210,7 @@ mod test {
         let t1 = replica.new_task(Status::Pending, s!("A")).unwrap();
         let t2 = replica.new_task(Status::Completed, s!("B")).unwrap();
         let _t = replica.new_task(Status::Pending, s!("C")).unwrap();
-        replica.gc().unwrap();
+        replica.rebuild_working_set().unwrap();
 
         let t1uuid = *t1.get_uuid();
         let t2uuid = t2.get_uuid().to_string();
@@ -238,7 +238,7 @@ mod test {
         replica.new_task(Status::Pending, s!("A")).unwrap();
         replica.new_task(Status::Completed, s!("B")).unwrap();
         replica.new_task(Status::Deleted, s!("C")).unwrap();
-        replica.gc().unwrap();
+        replica.rebuild_working_set().unwrap();
 
         let filter = Filter { conditions: vec![] };
         let mut filtered: Vec<_> = filtered_tasks(&mut replica, &filter)
@@ -309,7 +309,7 @@ mod test {
         replica.new_task(Status::Pending, s!("A")).unwrap();
         replica.new_task(Status::Completed, s!("B")).unwrap();
         replica.new_task(Status::Deleted, s!("C")).unwrap();
-        replica.gc().unwrap();
+        replica.rebuild_working_set().unwrap();
 
         let filter = Filter {
             conditions: vec![Condition::Status(Status::Pending)],

--- a/cli/src/invocation/report.rs
+++ b/cli/src/invocation/report.rs
@@ -163,7 +163,7 @@ mod test {
         t2.set_status(Status::Completed).unwrap();
         let t2 = t2.into_immut();
 
-        replica.rebuild_working_set().unwrap();
+        replica.rebuild_working_set(true).unwrap();
 
         [*t1.get_uuid(), *t2.get_uuid(), *t3.get_uuid()]
     }

--- a/cli/src/invocation/report.rs
+++ b/cli/src/invocation/report.rs
@@ -163,7 +163,7 @@ mod test {
         t2.set_status(Status::Completed).unwrap();
         let t2 = t2.into_immut();
 
-        replica.gc().unwrap();
+        replica.rebuild_working_set().unwrap();
 
         [*t1.get_uuid(), *t2.get_uuid(), *t3.get_uuid()]
     }

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -165,9 +165,12 @@ impl Replica {
         Ok(())
     }
 
-    /// Synchronize this replica against the given server.
+    /// Synchronize this replica against the given server.  The working set is rebuilt after
+    /// this occurs, but without renumbering, so any newly-pending tasks should appear in
+    /// the working set.
     pub fn sync(&mut self, server: &mut Box<dyn Server>) -> Fallible<()> {
-        self.taskdb.sync(server)
+        self.taskdb.sync(server)?;
+        self.rebuild_working_set(false)
     }
 
     /// Rebuild this replica's working set, based on whether tasks are pending or not.  If

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -172,7 +172,7 @@ impl Replica {
 
     /// Perform "garbage collection" on this replica.  In particular, this renumbers the working
     /// set to contain only pending tasks.
-    pub fn gc(&mut self) -> Fallible<()> {
+    pub fn rebuild_working_set(&mut self) -> Fallible<()> {
         let pending = String::from(Status::Pending.to_taskmap());
         self.taskdb
             .rebuild_working_set(|t| t.get("status") == Some(&pending))?;
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(t.get_status(), Status::Deleted);
         assert_eq!(t.get_description(), "gone");
 
-        rep.gc().unwrap();
+        rep.rebuild_working_set().unwrap();
 
         assert!(rep.get_working_set_index(t.get_uuid()).unwrap().is_none());
     }

--- a/taskchampion/src/taskstorage/inmemory.rs
+++ b/taskchampion/src/taskstorage/inmemory.rs
@@ -3,7 +3,7 @@
 use crate::taskstorage::{
     Operation, TaskMap, TaskStorage, TaskStorageTxn, VersionId, DEFAULT_BASE_VERSION,
 };
-use failure::Fallible;
+use failure::{bail, Fallible};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -112,6 +112,15 @@ impl<'t> TaskStorageTxn for Txn<'t> {
         let working_set = &mut self.mut_data_ref().working_set;
         working_set.push(Some(*uuid));
         Ok(working_set.len())
+    }
+
+    fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Fallible<()> {
+        let working_set = &mut self.mut_data_ref().working_set;
+        if index >= working_set.len() {
+            bail!("Index {} is not in the working set", index);
+        }
+        working_set[index] = uuid;
+        Ok(())
     }
 
     fn clear_working_set(&mut self) -> Fallible<()> {

--- a/taskchampion/src/taskstorage/mod.rs
+++ b/taskchampion/src/taskstorage/mod.rs
@@ -88,6 +88,10 @@ pub trait TaskStorageTxn {
     /// than the highest used index.
     fn add_to_working_set(&mut self, uuid: &Uuid) -> Fallible<usize>;
 
+    /// Update the working set task at the given index.  This cannot add a new item to the
+    /// working set.
+    fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Fallible<()>;
+
     /// Clear all tasks from the working set in preparation for a garbage-collection operation.
     /// Note that this is the only way items are removed from the set.
     fn clear_working_set(&mut self) -> Fallible<()>;


### PR DESCRIPTION
This should ensure that in most cases, any pending task is in the working set.  That's critical for the filter optimization that just scans the working set.

It can miss the case where a task is marked as not pending, but that just leaves an extra task in the set.  

Fixes #68.