### PR TITLE
Replace 'failure' with anyhow + thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,28 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -2231,18 +2215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,8 +2224,8 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 name = "taskchampion"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "chrono",
- "failure",
  "kv",
  "lmdb-rkv",
  "log",
@@ -2261,6 +2233,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempdir",
+ "thiserror",
  "tindercrypt",
  "ureq",
  "uuid",
@@ -2270,12 +2243,12 @@ dependencies = [
 name = "taskchampion-cli"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "atty",
  "config",
  "dirs 3.0.1",
  "env_logger",
- "failure",
  "log",
  "nom 6.0.1",
  "predicates",
@@ -2292,9 +2265,9 @@ version = "0.3.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "anyhow",
  "clap",
  "env_logger",
- "failure",
  "futures",
  "kv",
  "log",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.3.0"
 [dependencies]
 dirs = "^3.0.1"
 env_logger = "^0.8.2"
-failure = "^0.1.8"
+anyhow = "1.0"
 log = "^0.4.11"
 nom = "^6.0.1"
 prettytable-rs = "^0.8.0"

--- a/cli/src/argparse/command.rs
+++ b/cli/src/argparse/command.rs
@@ -1,6 +1,6 @@
 use super::args::*;
 use super::{ArgList, Subcommand};
-use failure::{format_err, Fallible};
+use anyhow::bail;
 use nom::{combinator::*, sequence::*, Err, IResult};
 
 /// A command is the overall command that the CLI should execute.
@@ -29,16 +29,16 @@ impl Command {
     }
 
     /// Parse a command from the given list of strings.
-    pub fn from_argv(argv: &[&str]) -> Fallible<Command> {
+    pub fn from_argv(argv: &[&str]) -> anyhow::Result<Command> {
         match Command::parse(argv) {
             Ok((&[], cmd)) => Ok(cmd),
-            Ok((trailing, _)) => Err(format_err!(
+            Ok((trailing, _)) => bail!(
                 "command line has trailing arguments: {:?}",
                 trailing
-            )),
+            ),
             Err(Err::Incomplete(_)) => unreachable!(),
-            Err(Err::Error(e)) => Err(format_err!("command line not recognized: {:?}", e)),
-            Err(Err::Failure(e)) => Err(format_err!("command line not recognized: {:?}", e)),
+            Err(Err::Error(e)) => bail!("command line not recognized: {:?}", e),
+            Err(Err::Failure(e)) => bail!("command line not recognized: {:?}", e),
         }
     }
 }

--- a/cli/src/argparse/command.rs
+++ b/cli/src/argparse/command.rs
@@ -32,10 +32,7 @@ impl Command {
     pub fn from_argv(argv: &[&str]) -> anyhow::Result<Command> {
         match Command::parse(argv) {
             Ok((&[], cmd)) => Ok(cmd),
-            Ok((trailing, _)) => bail!(
-                "command line has trailing arguments: {:?}",
-                trailing
-            ),
+            Ok((trailing, _)) => bail!("command line has trailing arguments: {:?}", trailing),
             Err(Err::Incomplete(_)) => unreachable!(),
             Err(Err::Error(e)) => bail!("command line not recognized: {:?}", e),
             Err(Err::Failure(e)) => bail!("command line not recognized: {:?}", e),

--- a/cli/src/argparse/filter.rs
+++ b/cli/src/argparse/filter.rs
@@ -1,7 +1,7 @@
 use super::args::{arg_matching, id_list, minus_tag, plus_tag, status_colon, TaskId};
 use super::ArgList;
 use crate::usage;
-use failure::{bail, Fallible};
+use anyhow::bail;
 use nom::{branch::alt, combinator::*, multi::fold_many0, IResult};
 use taskchampion::Status;
 
@@ -44,7 +44,7 @@ impl Condition {
     }
 
     /// Parse a single condition string
-    pub(crate) fn parse_str(input: &str) -> Fallible<Condition> {
+    pub(crate) fn parse_str(input: &str) -> anyhow::Result<Condition> {
         let input = &[input];
         Ok(match Condition::parse(input) {
             Ok((&[], cond)) => cond,

--- a/cli/src/invocation/cmd/add.rs
+++ b/cli/src/invocation/cmd/add.rs
@@ -1,5 +1,4 @@
 use crate::argparse::{DescriptionMod, Modification};
-use failure::Fallible;
 use taskchampion::{Replica, Status};
 use termcolor::WriteColor;
 
@@ -7,7 +6,7 @@ pub(crate) fn execute<W: WriteColor>(
     w: &mut W,
     replica: &mut Replica,
     modification: Modification,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     let description = match modification.description {
         DescriptionMod::Set(ref s) => s.clone(),
         _ => "(no description)".to_owned(),

--- a/cli/src/invocation/cmd/gc.rs
+++ b/cli/src/invocation/cmd/gc.rs
@@ -1,8 +1,7 @@
-use failure::Fallible;
 use taskchampion::Replica;
 use termcolor::WriteColor;
 
-pub(crate) fn execute<W: WriteColor>(w: &mut W, replica: &mut Replica) -> Fallible<()> {
+pub(crate) fn execute<W: WriteColor>(w: &mut W, replica: &mut Replica) -> anyhow::Result<()> {
     log::debug!("rebuilding working set");
     replica.rebuild_working_set(true)?;
     writeln!(w, "garbage collected.")?;

--- a/cli/src/invocation/cmd/help.rs
+++ b/cli/src/invocation/cmd/help.rs
@@ -1,12 +1,11 @@
 use crate::usage::Usage;
-use failure::Fallible;
 use termcolor::WriteColor;
 
 pub(crate) fn execute<W: WriteColor>(
     w: &mut W,
     command_name: String,
     summary: bool,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     let usage = Usage::new();
     usage.write_help(w, command_name.as_ref(), summary)?;
     Ok(())

--- a/cli/src/invocation/cmd/info.rs
+++ b/cli/src/invocation/cmd/info.rs
@@ -1,7 +1,6 @@
 use crate::argparse::Filter;
 use crate::invocation::filtered_tasks;
 use crate::table;
-use failure::Fallible;
 use prettytable::{cell, row, Table};
 use taskchampion::Replica;
 use termcolor::WriteColor;
@@ -11,7 +10,7 @@ pub(crate) fn execute<W: WriteColor>(
     replica: &mut Replica,
     filter: Filter,
     debug: bool,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     let working_set = replica.working_set()?;
 
     for task in filtered_tasks(replica, &filter)? {

--- a/cli/src/invocation/cmd/modify.rs
+++ b/cli/src/invocation/cmd/modify.rs
@@ -1,6 +1,5 @@
 use crate::argparse::{Filter, Modification};
 use crate::invocation::{apply_modification, filtered_tasks};
-use failure::Fallible;
 use taskchampion::Replica;
 use termcolor::WriteColor;
 
@@ -9,7 +8,7 @@ pub(crate) fn execute<W: WriteColor>(
     replica: &mut Replica,
     filter: Filter,
     modification: Modification,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     for task in filtered_tasks(replica, &filter)? {
         let mut task = task.into_mut(replica);
 

--- a/cli/src/invocation/cmd/report.rs
+++ b/cli/src/invocation/cmd/report.rs
@@ -1,7 +1,6 @@
 use crate::argparse::Filter;
 use crate::invocation::display_report;
 use config::Config;
-use failure::Fallible;
 use taskchampion::Replica;
 use termcolor::WriteColor;
 
@@ -11,7 +10,7 @@ pub(crate) fn execute<W: WriteColor>(
     settings: &Config,
     report_name: String,
     filter: Filter,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     display_report(w, replica, settings, report_name, filter)
 }
 

--- a/cli/src/invocation/cmd/sync.rs
+++ b/cli/src/invocation/cmd/sync.rs
@@ -1,4 +1,3 @@
-use failure::Fallible;
 use taskchampion::{server::Server, Replica};
 use termcolor::WriteColor;
 
@@ -6,8 +5,8 @@ pub(crate) fn execute<W: WriteColor>(
     w: &mut W,
     replica: &mut Replica,
     server: &mut Box<dyn Server>,
-) -> Fallible<()> {
-    replica.sync(server)?;
+) -> anyhow::Result<()> {
+    replica.sync(server).unwrap();
     writeln!(w, "sync complete.")?;
     Ok(())
 }

--- a/cli/src/invocation/cmd/version.rs
+++ b/cli/src/invocation/cmd/version.rs
@@ -1,7 +1,6 @@
-use failure::Fallible;
 use termcolor::{ColorSpec, WriteColor};
 
-pub(crate) fn execute<W: WriteColor>(w: &mut W) -> Fallible<()> {
+pub(crate) fn execute<W: WriteColor>(w: &mut W) -> anyhow::Result<()> {
     write!(w, "TaskChampion ")?;
     w.set_color(ColorSpec::new().set_bold(true))?;
     writeln!(w, "{}", env!("CARGO_PKG_VERSION"))?;

--- a/cli/src/invocation/filter.rs
+++ b/cli/src/invocation/filter.rs
@@ -1,5 +1,4 @@
 use crate::argparse::{Condition, Filter, TaskId};
-use failure::Fallible;
 use std::collections::HashSet;
 use std::convert::TryInto;
 use taskchampion::{Replica, Status, Tag, Task, Uuid, WorkingSet};
@@ -108,7 +107,7 @@ fn universe_for_filter(filter: &Filter) -> Universe {
 pub(super) fn filtered_tasks(
     replica: &mut Replica,
     filter: &Filter,
-) -> Fallible<impl Iterator<Item = Task>> {
+) -> anyhow::Result<impl Iterator<Item = Task>> {
     let mut res = vec![];
 
     log::debug!("Applying filter {:?}", filter);
@@ -253,7 +252,7 @@ mod test {
     }
 
     #[test]
-    fn tag_filtering() -> Fallible<()> {
+    fn tag_filtering() -> anyhow::Result<()> {
         let mut replica = test_replica();
         let yes: Tag = "yes".try_into()?;
         let no: Tag = "no".try_into()?;

--- a/cli/src/invocation/modify.rs
+++ b/cli/src/invocation/modify.rs
@@ -1,5 +1,4 @@
 use crate::argparse::{DescriptionMod, Modification};
-use failure::Fallible;
 use std::convert::TryInto;
 use taskchampion::TaskMut;
 use termcolor::WriteColor;
@@ -9,7 +8,7 @@ pub(super) fn apply_modification<W: WriteColor>(
     w: &mut W,
     task: &mut TaskMut,
     modification: &Modification,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     match modification.description {
         DescriptionMod::Set(ref description) => task.set_description(description.clone())?,
         DescriptionMod::Prepend(ref description) => {

--- a/cli/src/invocation/report.rs
+++ b/cli/src/invocation/report.rs
@@ -3,7 +3,6 @@ use crate::invocation::filtered_tasks;
 use crate::report::{Column, Property, Report, SortBy};
 use crate::table;
 use config::Config;
-use failure::{format_err, Fallible};
 use prettytable::{Row, Table};
 use std::cmp::Ordering;
 use taskchampion::{Replica, Task, WorkingSet};
@@ -83,13 +82,13 @@ pub(super) fn display_report<W: WriteColor>(
     settings: &Config,
     report_name: String,
     filter: Filter,
-) -> Fallible<()> {
+) -> anyhow::Result<()> {
     let mut t = Table::new();
     let working_set = replica.working_set()?;
 
     // Get the report from settings
     let mut report = Report::from_config(settings.get(&format!("reports.{}", report_name))?)
-        .map_err(|e| format_err!("report.{}{}", report_name, e))?;
+        .map_err(|e| anyhow::anyhow!("report.{}{}", report_name, e))?;
 
     // include any user-supplied filter conditions
     report.filter = report.filter.intersect(filter);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::unnecessary_wraps)] // for Rust 1.50, https://github.com/rust-lang/rust-clippy/pull/6765
 /*!
 This crate implements the command-line interface to TaskChampion.
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -29,7 +29,6 @@ For the public TaskChampion Rust API, see the `taskchampion` crate.
 
 */
 
-use failure::Fallible;
 use std::os::unix::ffi::OsStringExt;
 use std::string::FromUtf8Error;
 
@@ -45,7 +44,7 @@ mod usage;
 
 /// The main entry point for the command-line interface.  This builds an Invocation
 /// from the particulars of the operating-system interface, and then executes it.
-pub fn main() -> Fallible<()> {
+pub fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     // parse the command line into a vector of &str, failing if

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,7 +1,7 @@
 //! This module contains the data structures used to define reports.
 
 use crate::argparse::{Condition, Filter};
-use anyhow::{bail};
+use anyhow::bail;
 
 /// A report specifies a filter as well as a sort order and information about which
 /// task attributes to display
@@ -85,7 +85,9 @@ impl Report {
                 .map_err(|e| anyhow::anyhow!(".sort: {}", e))?
                 .drain(..)
                 .enumerate()
-                .map(|(i, v)| Sort::from_config(v).map_err(|e| anyhow::anyhow!(".sort[{}]{}", i, e)))
+                .map(|(i, v)| {
+                    Sort::from_config(v).map_err(|e| anyhow::anyhow!(".sort[{}]{}", i, e))
+                })
                 .collect::<anyhow::Result<Vec<_>>>()?
         } else {
             vec![]
@@ -98,7 +100,9 @@ impl Report {
             .map_err(|e| anyhow::anyhow!(".columns: {}", e))?
             .drain(..)
             .enumerate()
-            .map(|(i, v)| Column::from_config(v).map_err(|e| anyhow::anyhow!(".columns[{}]{}", i, e)))
+            .map(|(i, v)| {
+                Column::from_config(v).map_err(|e| anyhow::anyhow!(".columns[{}]{}", i, e))
+            })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         let conditions = if let Some(conditions) = map.remove("filter") {

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,7 +1,7 @@
 //! This module contains the data structures used to define reports.
 
 use crate::argparse::{Condition, Filter};
-use failure::{bail, format_err, Fallible};
+use anyhow::{bail};
 
 /// A report specifies a filter as well as a sort order and information about which
 /// task attributes to display
@@ -77,43 +77,43 @@ impl Report {
     /// Create a Report from a config value.  This should be the `report.<report_name>` value.
     /// The error message begins with any additional path information, e.g., `.sort[1].sort_by:
     /// ..`.
-    pub(crate) fn from_config(cfg: config::Value) -> Fallible<Report> {
-        let mut map = cfg.into_table().map_err(|e| format_err!(": {}", e))?;
+    pub(crate) fn from_config(cfg: config::Value) -> anyhow::Result<Report> {
+        let mut map = cfg.into_table().map_err(|e| anyhow::anyhow!(": {}", e))?;
         let sort = if let Some(sort_array) = map.remove("sort") {
             sort_array
                 .into_array()
-                .map_err(|e| format_err!(".sort: {}", e))?
+                .map_err(|e| anyhow::anyhow!(".sort: {}", e))?
                 .drain(..)
                 .enumerate()
-                .map(|(i, v)| Sort::from_config(v).map_err(|e| format_err!(".sort[{}]{}", i, e)))
-                .collect::<Fallible<Vec<_>>>()?
+                .map(|(i, v)| Sort::from_config(v).map_err(|e| anyhow::anyhow!(".sort[{}]{}", i, e)))
+                .collect::<anyhow::Result<Vec<_>>>()?
         } else {
             vec![]
         };
 
         let columns = map
             .remove("columns")
-            .ok_or_else(|| format_err!(": 'columns' property is required"))?
+            .ok_or_else(|| anyhow::anyhow!(": 'columns' property is required"))?
             .into_array()
-            .map_err(|e| format_err!(".columns: {}", e))?
+            .map_err(|e| anyhow::anyhow!(".columns: {}", e))?
             .drain(..)
             .enumerate()
-            .map(|(i, v)| Column::from_config(v).map_err(|e| format_err!(".columns[{}]{}", i, e)))
-            .collect::<Fallible<Vec<_>>>()?;
+            .map(|(i, v)| Column::from_config(v).map_err(|e| anyhow::anyhow!(".columns[{}]{}", i, e)))
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         let conditions = if let Some(conditions) = map.remove("filter") {
             conditions
                 .into_array()
-                .map_err(|e| format_err!(".filter: {}", e))?
+                .map_err(|e| anyhow::anyhow!(".filter: {}", e))?
                 .drain(..)
                 .enumerate()
                 .map(|(i, v)| {
                     v.into_str()
                         .map_err(|e| e.into())
                         .and_then(|s| Condition::parse_str(&s))
-                        .map_err(|e| format_err!(".filter[{}]: {}", i, e))
+                        .map_err(|e| anyhow::anyhow!(".filter[{}]: {}", i, e))
                 })
-                .collect::<Fallible<Vec<_>>>()?
+                .collect::<anyhow::Result<Vec<_>>>()?
         } else {
             vec![]
         };
@@ -133,18 +133,18 @@ impl Report {
 }
 
 impl Column {
-    pub(crate) fn from_config(cfg: config::Value) -> Fallible<Column> {
-        let mut map = cfg.into_table().map_err(|e| format_err!(": {}", e))?;
+    pub(crate) fn from_config(cfg: config::Value) -> anyhow::Result<Column> {
+        let mut map = cfg.into_table().map_err(|e| anyhow::anyhow!(": {}", e))?;
         let label = map
             .remove("label")
-            .ok_or_else(|| format_err!(": 'label' property is required"))?
+            .ok_or_else(|| anyhow::anyhow!(": 'label' property is required"))?
             .into_str()
-            .map_err(|e| format_err!(".label: {}", e))?;
+            .map_err(|e| anyhow::anyhow!(".label: {}", e))?;
         let property: config::Value = map
             .remove("property")
-            .ok_or_else(|| format_err!(": 'property' property is required"))?;
+            .ok_or_else(|| anyhow::anyhow!(": 'property' property is required"))?;
         let property =
-            Property::from_config(property).map_err(|e| format_err!(".property{}", e))?;
+            Property::from_config(property).map_err(|e| anyhow::anyhow!(".property{}", e))?;
 
         if !map.is_empty() {
             bail!(": unknown properties");
@@ -155,8 +155,8 @@ impl Column {
 }
 
 impl Property {
-    pub(crate) fn from_config(cfg: config::Value) -> Fallible<Property> {
-        let s = cfg.into_str().map_err(|e| format_err!(": {}", e))?;
+    pub(crate) fn from_config(cfg: config::Value) -> anyhow::Result<Property> {
+        let s = cfg.into_str().map_err(|e| anyhow::anyhow!(": {}", e))?;
         Ok(match s.as_ref() {
             "id" => Property::Id,
             "uuid" => Property::Uuid,
@@ -169,18 +169,18 @@ impl Property {
 }
 
 impl Sort {
-    pub(crate) fn from_config(cfg: config::Value) -> Fallible<Sort> {
-        let mut map = cfg.into_table().map_err(|e| format_err!(": {}", e))?;
+    pub(crate) fn from_config(cfg: config::Value) -> anyhow::Result<Sort> {
+        let mut map = cfg.into_table().map_err(|e| anyhow::anyhow!(": {}", e))?;
         let ascending = match map.remove("ascending") {
             Some(v) => v
                 .into_bool()
-                .map_err(|e| format_err!(".ascending: {}", e))?,
+                .map_err(|e| anyhow::anyhow!(".ascending: {}", e))?,
             None => true, // default
         };
         let sort_by: config::Value = map
             .remove("sort_by")
-            .ok_or_else(|| format_err!(": 'sort_by' property is required"))?;
-        let sort_by = SortBy::from_config(sort_by).map_err(|e| format_err!(".sort_by{}", e))?;
+            .ok_or_else(|| anyhow::anyhow!(": 'sort_by' property is required"))?;
+        let sort_by = SortBy::from_config(sort_by).map_err(|e| anyhow::anyhow!(".sort_by{}", e))?;
 
         if !map.is_empty() {
             bail!(": unknown properties");
@@ -191,8 +191,8 @@ impl Sort {
 }
 
 impl SortBy {
-    pub(crate) fn from_config(cfg: config::Value) -> Fallible<SortBy> {
-        let s = cfg.into_str().map_err(|e| format_err!(": {}", e))?;
+    pub(crate) fn from_config(cfg: config::Value) -> anyhow::Result<SortBy> {
+        let s = cfg.into_str().map_err(|e| anyhow::anyhow!(": {}", e))?;
         Ok(match s.as_ref() {
             "id" => SortBy::Id,
             "uuid" => SortBy::Uuid,

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -29,7 +29,7 @@ pub(crate) struct Column {
 #[derive(Clone, Debug, PartialEq)]
 #[allow(dead_code)]
 pub(crate) enum Property {
-    /// The task's ID, either working-set index or Uuid if no in the working set
+    /// The task's ID, either working-set index or Uuid if not in the working set
     Id,
 
     /// The task's full UUID

--- a/cli/src/settings.rs
+++ b/cli/src/settings.rs
@@ -1,5 +1,4 @@
 use config::{Config, Environment, File, FileFormat, FileSourceFile, FileSourceString};
-use failure::Fallible;
 use std::env;
 use std::path::PathBuf;
 
@@ -34,7 +33,7 @@ reports:
 "#;
 
 /// Get the default settings for this application
-pub(crate) fn default_settings() -> Fallible<Config> {
+pub(crate) fn default_settings() -> anyhow::Result<Config> {
     let mut settings = Config::default();
 
     // set up defaults
@@ -62,7 +61,7 @@ pub(crate) fn default_settings() -> Fallible<Config> {
     Ok(settings)
 }
 
-pub(crate) fn read_settings() -> Fallible<Config> {
+pub(crate) fn read_settings() -> anyhow::Result<Config> {
     let mut settings = default_settings()?;
 
     // load either from the path in TASKCHAMPION_CONFIG, or from CONFIG_DIR/taskchampion

--- a/sync-server/Cargo.toml
+++ b/sync-server/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 uuid = { version = "^0.8.1", features = ["serde", "v4"] }
 actix-web = "^3.3.0"
-failure = "^0.1.8"
+anyhow = "1.0"
 futures = "^0.3.8"
 serde = "^1.0.104"
 kv = {version = "^0.10.0", features = ["msgpack-value"]}

--- a/sync-server/src/api/mod.rs
+++ b/sync-server/src/api/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn api_scope() -> Scope {
 }
 
 /// Convert a failure::Error to an Actix ISE
-fn failure_to_ise(err: failure::Error) -> impl actix_web::ResponseError {
+fn failure_to_ise(err: anyhow::Error) -> impl actix_web::ResponseError {
     error::InternalError::new(err, StatusCode::INTERNAL_SERVER_ERROR)
 }
 

--- a/sync-server/src/main.rs
+++ b/sync-server/src/main.rs
@@ -4,7 +4,6 @@ use crate::storage::{KVStorage, Storage};
 use actix_web::{get, middleware::Logger, web, App, HttpServer, Responder, Scope};
 use api::{api_scope, ServerState};
 use clap::Arg;
-use failure::Fallible;
 
 mod api;
 mod server;
@@ -27,7 +26,7 @@ pub(crate) fn app_scope(server_state: ServerState) -> Scope {
 }
 
 #[actix_web::main]
-async fn main() -> Fallible<()> {
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let matches = clap::App::new("taskchampion-sync-server")
         .version(env!("CARGO_PKG_VERSION"))

--- a/sync-server/src/server.rs
+++ b/sync-server/src/server.rs
@@ -1,7 +1,6 @@
 //! This module implements the core logic of the server: handling transactions, upholding
 //! invariants, and so on.
 use crate::storage::{Client, StorageTxn};
-use failure::Fallible;
 use uuid::Uuid;
 
 /// The distinguished value for "no version"
@@ -23,7 +22,7 @@ pub(crate) fn get_child_version<'a>(
     mut txn: Box<dyn StorageTxn + 'a>,
     client_key: ClientKey,
     parent_version_id: VersionId,
-) -> Fallible<Option<GetVersionResult>> {
+) -> anyhow::Result<Option<GetVersionResult>> {
     Ok(txn
         .get_version_by_parent(client_key, parent_version_id)?
         .map(|version| GetVersionResult {
@@ -48,7 +47,7 @@ pub(crate) fn add_version<'a>(
     client: Client,
     parent_version_id: VersionId,
     history_segment: HistorySegment,
-) -> Fallible<AddVersionResult> {
+) -> anyhow::Result<AddVersionResult> {
     log::debug!(
         "add_version(client_key: {}, parent_version_id: {})",
         client_key,
@@ -84,7 +83,7 @@ mod test {
     use crate::storage::{InMemoryStorage, Storage};
 
     #[test]
-    fn gcv_not_found() -> Fallible<()> {
+    fn gcv_not_found() -> anyhow::Result<()> {
         let storage = InMemoryStorage::new();
         let txn = storage.txn()?;
         let client_key = Uuid::new_v4();
@@ -94,7 +93,7 @@ mod test {
     }
 
     #[test]
-    fn gcv_found() -> Fallible<()> {
+    fn gcv_found() -> anyhow::Result<()> {
         let storage = InMemoryStorage::new();
         let mut txn = storage.txn()?;
         let client_key = Uuid::new_v4();
@@ -121,7 +120,7 @@ mod test {
     }
 
     #[test]
-    fn av_conflict() -> Fallible<()> {
+    fn av_conflict() -> anyhow::Result<()> {
         let storage = InMemoryStorage::new();
         let mut txn = storage.txn()?;
         let client_key = Uuid::new_v4();
@@ -154,7 +153,7 @@ mod test {
         Ok(())
     }
 
-    fn test_av_success(latest_version_id_nil: bool) -> Fallible<()> {
+    fn test_av_success(latest_version_id_nil: bool) -> anyhow::Result<()> {
         let storage = InMemoryStorage::new();
         let mut txn = storage.txn()?;
         let client_key = Uuid::new_v4();
@@ -198,12 +197,12 @@ mod test {
     }
 
     #[test]
-    fn av_success_with_existing_history() -> Fallible<()> {
+    fn av_success_with_existing_history() -> anyhow::Result<()> {
         test_av_success(true)
     }
 
     #[test]
-    fn av_success_nil_latest_version_id() -> Fallible<()> {
+    fn av_success_nil_latest_version_id() -> anyhow::Result<()> {
         test_av_success(false)
     }
 }

--- a/sync-server/src/server.rs
+++ b/sync-server/src/server.rs
@@ -132,13 +132,7 @@ mod test {
         };
 
         assert_eq!(
-            add_version(
-                txn,
-                client_key,
-                client,
-                parent_version_id,
-                history_segment.clone()
-            )?,
+            add_version(txn, client_key, client, parent_version_id, history_segment)?,
             AddVersionResult::ExpectedParentVersion(existing_parent_version_id)
         );
 

--- a/sync-server/src/storage/mod.rs
+++ b/sync-server/src/storage/mod.rs
@@ -1,4 +1,3 @@
-use failure::Fallible;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -24,24 +23,24 @@ pub(crate) struct Version {
 
 pub(crate) trait StorageTxn {
     /// Get information about the given client
-    fn get_client(&mut self, client_key: Uuid) -> Fallible<Option<Client>>;
+    fn get_client(&mut self, client_key: Uuid) -> anyhow::Result<Option<Client>>;
 
     /// Create a new client with the given latest_version_id
-    fn new_client(&mut self, client_key: Uuid, latest_version_id: Uuid) -> Fallible<()>;
+    fn new_client(&mut self, client_key: Uuid, latest_version_id: Uuid) -> anyhow::Result<()>;
 
     /// Set the client's latest_version_id
     fn set_client_latest_version_id(
         &mut self,
         client_key: Uuid,
         latest_version_id: Uuid,
-    ) -> Fallible<()>;
+    ) -> anyhow::Result<()>;
 
     /// Get a version, indexed by parent version id
     fn get_version_by_parent(
         &mut self,
         client_key: Uuid,
         parent_version_id: Uuid,
-    ) -> Fallible<Option<Version>>;
+    ) -> anyhow::Result<Option<Version>>;
 
     /// Add a version (that must not already exist)
     fn add_version(
@@ -50,16 +49,16 @@ pub(crate) trait StorageTxn {
         version_id: Uuid,
         parent_version_id: Uuid,
         history_segment: Vec<u8>,
-    ) -> Fallible<()>;
+    ) -> anyhow::Result<()>;
 
     /// Commit any changes made in the transaction.  It is an error to call this more than
     /// once.  It is safe to skip this call for read-only operations.
-    fn commit(&mut self) -> Fallible<()>;
+    fn commit(&mut self) -> anyhow::Result<()>;
 }
 
 /// A trait for objects able to act as storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
 pub(crate) trait Storage: Send + Sync {
     /// Begin a transaction
-    fn txn<'a>(&'a self) -> Fallible<Box<dyn StorageTxn + 'a>>;
+    fn txn<'a>(&'a self) -> anyhow::Result<Box<dyn StorageTxn + 'a>>;
 }

--- a/taskchampion/Cargo.toml
+++ b/taskchampion/Cargo.toml
@@ -15,7 +15,8 @@ uuid = { version = "^0.8.1", features = ["serde", "v4"] }
 serde = "^1.0.104"
 serde_json = "^1.0"
 chrono = { version = "^0.4.10", features = ["serde"] }
-failure = {version = "^0.1.5", features = ["derive"] }
+anyhow = "1.0"
+thiserror = "1.0"
 kv = {version = "^0.10.0", features = ["msgpack-value"]}
 lmdb-rkv = {version = "^0.12.3"}
 ureq = "^1.5.2"

--- a/taskchampion/src/errors.rs
+++ b/taskchampion/src/errors.rs
@@ -1,7 +1,6 @@
-use failure::Fail;
-
-#[derive(Debug, Fail, Eq, PartialEq, Clone)]
+use thiserror::Error;
+#[derive(Debug, Error, Eq, PartialEq, Clone)]
 pub enum Error {
-    #[fail(display = "Task Database Error: {}", _0)]
+    #[error("Task Database Error: {}", _0)]
     DBError(String),
 }

--- a/taskchampion/src/server/config.rs
+++ b/taskchampion/src/server/config.rs
@@ -1,6 +1,5 @@
 use super::types::Server;
 use super::{LocalServer, RemoteServer};
-use failure::Fallible;
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -27,7 +26,7 @@ pub enum ServerConfig {
 
 impl ServerConfig {
     /// Get a server based on this configuration
-    pub fn into_server(self) -> Fallible<Box<dyn Server>> {
+    pub fn into_server(self) -> anyhow::Result<Box<dyn Server>> {
         Ok(match self {
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             ServerConfig::Remote {

--- a/taskchampion/src/server/local.rs
+++ b/taskchampion/src/server/local.rs
@@ -132,7 +132,10 @@ impl<'t> Server for LocalServer<'t> {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> anyhow::Result<GetVersionResult> {
         if let Some(version) = self.get_version_by_parent_version_id(parent_version_id)? {
             Ok(GetVersionResult::Version {
                 version_id: version.version_id,

--- a/taskchampion/src/server/local.rs
+++ b/taskchampion/src/server/local.rs
@@ -2,7 +2,6 @@ use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, VersionId, NO_VERSION_ID,
 };
 use crate::utils::Key;
-use failure::Fallible;
 use kv::msgpack::Msgpack;
 use kv::{Bucket, Config, Error, Integer, Serde, Store, ValueBuf};
 use serde::{Deserialize, Serialize};
@@ -25,7 +24,7 @@ pub struct LocalServer<'t> {
 
 impl<'t> LocalServer<'t> {
     /// A test server has no notion of clients, signatures, encryption, etc.
-    pub fn new<P: AsRef<Path>>(directory: P) -> Fallible<LocalServer<'t>> {
+    pub fn new<P: AsRef<Path>>(directory: P) -> anyhow::Result<LocalServer<'t>> {
         let mut config = Config::default(directory);
         config.bucket("versions", None);
         config.bucket("numbers", None);
@@ -48,7 +47,7 @@ impl<'t> LocalServer<'t> {
         })
     }
 
-    fn get_latest_version_id(&mut self) -> Fallible<VersionId> {
+    fn get_latest_version_id(&mut self) -> anyhow::Result<VersionId> {
         let txn = self.store.read_txn()?;
         let base_version = match txn.get(&self.latest_version_bucket, 0.into()) {
             Ok(buf) => buf,
@@ -60,7 +59,7 @@ impl<'t> LocalServer<'t> {
         Ok(base_version as VersionId)
     }
 
-    fn set_latest_version_id(&mut self, version_id: VersionId) -> Fallible<()> {
+    fn set_latest_version_id(&mut self, version_id: VersionId) -> anyhow::Result<()> {
         let mut txn = self.store.write_txn()?;
         txn.set(
             &self.latest_version_bucket,
@@ -74,7 +73,7 @@ impl<'t> LocalServer<'t> {
     fn get_version_by_parent_version_id(
         &mut self,
         parent_version_id: VersionId,
-    ) -> Fallible<Option<Version>> {
+    ) -> anyhow::Result<Option<Version>> {
         let txn = self.store.read_txn()?;
 
         let version = match txn.get(&self.versions_bucket, parent_version_id.into()) {
@@ -87,7 +86,7 @@ impl<'t> LocalServer<'t> {
         Ok(Some(version))
     }
 
-    fn add_version_by_parent_version_id(&mut self, version: Version) -> Fallible<()> {
+    fn add_version_by_parent_version_id(&mut self, version: Version) -> anyhow::Result<()> {
         let mut txn = self.store.write_txn()?;
         txn.set(
             &self.versions_bucket,
@@ -109,7 +108,7 @@ impl<'t> Server for LocalServer<'t> {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> Fallible<AddVersionResult> {
+    ) -> anyhow::Result<AddVersionResult> {
         // no client lookup
         // no signature validation
 
@@ -133,7 +132,7 @@ impl<'t> Server for LocalServer<'t> {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Fallible<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
         if let Some(version) = self.get_version_by_parent_version_id(parent_version_id)? {
             Ok(GetVersionResult::Version {
                 version_id: version.version_id,
@@ -149,11 +148,10 @@ impl<'t> Server for LocalServer<'t> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use failure::Fallible;
     use tempdir::TempDir;
 
     #[test]
-    fn test_empty() -> Fallible<()> {
+    fn test_empty() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
         let mut server = LocalServer::new(&tmp_dir.path())?;
         let child_version = server.get_child_version(NO_VERSION_ID)?;
@@ -162,7 +160,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_zero_base() -> Fallible<()> {
+    fn test_add_zero_base() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
         let mut server = LocalServer::new(&tmp_dir.path())?;
         let history = b"1234".to_vec();
@@ -187,7 +185,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_nonzero_base() -> Fallible<()> {
+    fn test_add_nonzero_base() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
         let mut server = LocalServer::new(&tmp_dir.path())?;
         let history = b"1234".to_vec();
@@ -215,7 +213,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_nonzero_base_forbidden() -> Fallible<()> {
+    fn test_add_nonzero_base_forbidden() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
         let mut server = LocalServer::new(&tmp_dir.path())?;
         let history = b"1234".to_vec();

--- a/taskchampion/src/server/remote/crypto.rs
+++ b/taskchampion/src/server/remote/crypto.rs
@@ -62,7 +62,9 @@ impl TryFrom<ureq::Response> for HistoryCiphertext {
             reader.read_to_end(&mut bytes)?;
             Ok(Self(bytes))
         } else {
-            Err(anyhow::anyhow!("Response did not have expected content-type"))
+            Err(anyhow::anyhow!(
+                "Response did not have expected content-type"
+            ))
         }
     }
 }

--- a/taskchampion/src/server/remote/mod.rs
+++ b/taskchampion/src/server/remote/mod.rs
@@ -83,7 +83,10 @@ impl Server for RemoteServer {
         }
     }
 
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> anyhow::Result<GetVersionResult> {
         let url = format!(
             "{}/client/get-child-version/{}",
             self.origin, parent_version_id

--- a/taskchampion/src/server/remote/mod.rs
+++ b/taskchampion/src/server/remote/mod.rs
@@ -1,5 +1,4 @@
 use crate::server::{AddVersionResult, GetVersionResult, HistorySegment, Server, VersionId};
-use failure::{format_err, Fallible};
 use std::convert::TryInto;
 use uuid::Uuid;
 
@@ -31,8 +30,8 @@ impl RemoteServer {
 }
 
 /// Convert a ureq::Response to an Error
-fn resp_to_error(resp: ureq::Response) -> failure::Error {
-    return format_err!(
+fn resp_to_error(resp: ureq::Response) -> anyhow::Error {
+    return anyhow::anyhow!(
         "error {}: {}",
         resp.status(),
         resp.into_string()
@@ -41,12 +40,12 @@ fn resp_to_error(resp: ureq::Response) -> failure::Error {
 }
 
 /// Read a UUID-bearing header or fail trying
-fn get_uuid_header(resp: &ureq::Response, name: &str) -> Fallible<Uuid> {
+fn get_uuid_header(resp: &ureq::Response, name: &str) -> anyhow::Result<Uuid> {
     let value = resp
         .header(name)
-        .ok_or_else(|| format_err!("Response does not have {} header", name))?;
+        .ok_or_else(|| anyhow::anyhow!("Response does not have {} header", name))?;
     let value = Uuid::parse_str(value)
-        .map_err(|e| format_err!("{} header is not a valid UUID: {}", name, e))?;
+        .map_err(|e| anyhow::anyhow!("{} header is not a valid UUID: {}", name, e))?;
     Ok(value)
 }
 
@@ -55,7 +54,7 @@ impl Server for RemoteServer {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> Fallible<AddVersionResult> {
+    ) -> anyhow::Result<AddVersionResult> {
         let url = format!("{}/client/add-version/{}", self.origin, parent_version_id);
         let history_cleartext = HistoryCleartext {
             parent_version_id,
@@ -84,7 +83,7 @@ impl Server for RemoteServer {
         }
     }
 
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Fallible<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
         let url = format!(
             "{}/client/get-child-version/{}",
             self.origin, parent_version_id

--- a/taskchampion/src/server/test.rs
+++ b/taskchampion/src/server/test.rs
@@ -63,7 +63,10 @@ impl Server for TestServer {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
+    fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> anyhow::Result<GetVersionResult> {
         if let Some(version) = self.versions.get(&parent_version_id) {
             Ok(GetVersionResult::Version {
                 version_id: version.version_id,

--- a/taskchampion/src/server/test.rs
+++ b/taskchampion/src/server/test.rs
@@ -1,7 +1,6 @@
 use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, VersionId, NO_VERSION_ID,
 };
-use failure::Fallible;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -34,7 +33,7 @@ impl Server for TestServer {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> Fallible<AddVersionResult> {
+    ) -> anyhow::Result<AddVersionResult> {
         // no client lookup
         // no signature validation
 
@@ -64,7 +63,7 @@ impl Server for TestServer {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Fallible<GetVersionResult> {
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult> {
         if let Some(version) = self.versions.get(&parent_version_id) {
             Ok(GetVersionResult::Version {
                 version_id: version.version_id,

--- a/taskchampion/src/server/types.rs
+++ b/taskchampion/src/server/types.rs
@@ -1,4 +1,3 @@
-use failure::Fallible;
 use uuid::Uuid;
 
 /// Versions are referred to with sha2 hashes.
@@ -41,8 +40,8 @@ pub trait Server {
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
-    ) -> Fallible<AddVersionResult>;
+    ) -> anyhow::Result<AddVersionResult>;
 
     /// Get the version with the given parent VersionId
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Fallible<GetVersionResult>;
+    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult>;
 }

--- a/taskchampion/src/server/types.rs
+++ b/taskchampion/src/server/types.rs
@@ -43,5 +43,8 @@ pub trait Server {
     ) -> anyhow::Result<AddVersionResult>;
 
     /// Get the version with the given parent VersionId
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> anyhow::Result<GetVersionResult>;
+    fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> anyhow::Result<GetVersionResult>;
 }

--- a/taskchampion/src/storage/config.rs
+++ b/taskchampion/src/storage/config.rs
@@ -1,5 +1,4 @@
 use super::{InMemoryStorage, KVStorage, Storage};
-use failure::Fallible;
 use std::path::PathBuf;
 
 /// The configuration required for a replica's storage.
@@ -14,7 +13,7 @@ pub enum StorageConfig {
 }
 
 impl StorageConfig {
-    pub fn into_storage(self) -> Fallible<Box<dyn Storage>> {
+    pub fn into_storage(self) -> anyhow::Result<Box<dyn Storage>> {
         Ok(match self {
             StorageConfig::OnDisk { taskdb_dir } => Box::new(KVStorage::new(taskdb_dir)?),
             StorageConfig::InMemory => Box::new(InMemoryStorage::new()),

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -7,9 +7,9 @@ Typical uses of this crate do not interact directly with this module; [`StorageC
 However, users who wish to implement their own storage backends can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
 
 */
-use failure::Fallible;
 use std::collections::HashMap;
 use uuid::Uuid;
+use anyhow::Result;
 
 mod config;
 mod inmemory;
@@ -55,66 +55,66 @@ pub(crate) const DEFAULT_BASE_VERSION: Uuid = crate::server::NO_VERSION_ID;
 /// It is safe and performant to drop transactions that did not modify any data without committing.
 pub trait StorageTxn {
     /// Get an (immutable) task, if it is in the storage
-    fn get_task(&mut self, uuid: Uuid) -> Fallible<Option<TaskMap>>;
+    fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
 
     /// Create an (empty) task, only if it does not already exist.  Returns true if
     /// the task was created (did not already exist).
-    fn create_task(&mut self, uuid: Uuid) -> Fallible<bool>;
+    fn create_task(&mut self, uuid: Uuid) -> Result<bool>;
 
     /// Set a task, overwriting any existing task.  If the task does not exist, this implicitly
     /// creates it (use `get_task` to check first, if necessary).
-    fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Fallible<()>;
+    fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()>;
 
     /// Delete a task, if it exists.  Returns true if the task was deleted (already existed)
-    fn delete_task(&mut self, uuid: Uuid) -> Fallible<bool>;
+    fn delete_task(&mut self, uuid: Uuid) -> Result<bool>;
 
     /// Get the uuids and bodies of all tasks in the storage, in undefined order.
-    fn all_tasks(&mut self) -> Fallible<Vec<(Uuid, TaskMap)>>;
+    fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
 
     /// Get the uuids of all tasks in the storage, in undefined order.
-    fn all_task_uuids(&mut self) -> Fallible<Vec<Uuid>>;
+    fn all_task_uuids(&mut self) -> Result<Vec<Uuid>>;
 
     /// Get the current base_version for this storage -- the last version synced from the server.
-    fn base_version(&mut self) -> Fallible<VersionId>;
+    fn base_version(&mut self) -> Result<VersionId>;
 
     /// Set the current base_version for this storage.
-    fn set_base_version(&mut self, version: VersionId) -> Fallible<()>;
+    fn set_base_version(&mut self, version: VersionId) -> Result<()>;
 
     /// Get the current set of outstanding operations (operations that have not been sync'd to the
     /// server yet)
-    fn operations(&mut self) -> Fallible<Vec<Operation>>;
+    fn operations(&mut self) -> Result<Vec<Operation>>;
 
     /// Add an operation to the end of the list of operations in the storage.  Note that this
     /// merely *stores* the operation; it is up to the TaskDB to apply it.
-    fn add_operation(&mut self, op: Operation) -> Fallible<()>;
+    fn add_operation(&mut self, op: Operation) -> Result<()>;
 
     /// Replace the current list of operations with a new list.
-    fn set_operations(&mut self, ops: Vec<Operation>) -> Fallible<()>;
+    fn set_operations(&mut self, ops: Vec<Operation>) -> Result<()>;
 
     /// Get the entire working set, with each task UUID at its appropriate (1-based) index.
     /// Element 0 is always None.
-    fn get_working_set(&mut self) -> Fallible<Vec<Option<Uuid>>>;
+    fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>>;
 
     /// Add a task to the working set and return its (one-based) index.  This index will be one greater
     /// than the highest used index.
-    fn add_to_working_set(&mut self, uuid: Uuid) -> Fallible<usize>;
+    fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize>;
 
     /// Update the working set task at the given index.  This cannot add a new item to the
     /// working set.
-    fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Fallible<()>;
+    fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()>;
 
     /// Clear all tasks from the working set in preparation for a garbage-collection operation.
     /// Note that this is the only way items are removed from the set.
-    fn clear_working_set(&mut self) -> Fallible<()>;
+    fn clear_working_set(&mut self) -> Result<()>;
 
     /// Commit any changes made in the transaction.  It is an error to call this more than
     /// once.
-    fn commit(&mut self) -> Fallible<()>;
+    fn commit(&mut self) -> Result<()>;
 }
 
 /// A trait for objects able to act as task storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
 pub trait Storage {
     /// Begin a transaction
-    fn txn<'a>(&'a mut self) -> Fallible<Box<dyn StorageTxn + 'a>>;
+    fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + 'a>>;
 }

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -1,15 +1,13 @@
 /**
-
 This module defines the backend storage used by [`Replica`](crate::Replica).
 It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default on-disk implementation as well as an in-memory implementation for testing.
 
 Typical uses of this crate do not interact directly with this module; [`StorageConfig`](crate::StorageConfig) is sufficient.
 However, users who wish to implement their own storage backends can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
-
 */
+use anyhow::Result;
 use std::collections::HashMap;
 use uuid::Uuid;
-use anyhow::Result;
 
 mod config;
 mod inmemory;

--- a/taskchampion/src/task.rs
+++ b/taskchampion/src/task.rs
@@ -330,7 +330,11 @@ impl<'r> TaskMut<'r> {
         Ok(())
     }
 
-    fn set_string<S: Into<String>>(&mut self, property: S, value: Option<String>) -> anyhow::Result<()> {
+    fn set_string<S: Into<String>>(
+        &mut self,
+        property: S,
+        value: Option<String>,
+    ) -> anyhow::Result<()> {
         let property = property.into();
         self.lastmod()?;
         self.replica
@@ -346,7 +350,11 @@ impl<'r> TaskMut<'r> {
         Ok(())
     }
 
-    fn set_timestamp(&mut self, property: &str, value: Option<DateTime<Utc>>) -> anyhow::Result<()> {
+    fn set_timestamp(
+        &mut self,
+        property: &str,
+        value: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<()> {
         self.lastmod()?;
         if let Some(value) = value {
             let ts = format!("{}", value.timestamp());

--- a/taskchampion/src/taskdb.rs
+++ b/taskchampion/src/taskdb.rs
@@ -107,7 +107,11 @@ impl TaskDB {
     /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
     /// are not already in the working set but should be.  The rebuild occurs in a single
     /// trasnsaction against the storage backend.
-    pub fn rebuild_working_set<F>(&mut self, in_working_set: F, renumber: bool) -> anyhow::Result<()>
+    pub fn rebuild_working_set<F>(
+        &mut self,
+        in_working_set: F,
+        renumber: bool,
+    ) -> anyhow::Result<()>
     where
         F: Fn(&TaskMap) -> bool,
     {
@@ -246,9 +250,7 @@ impl TaskDB {
                     );
                     if let Some(requested) = requested_parent_version_id {
                         if parent_version_id == requested {
-                            anyhow::bail!(
-                                "Server's task history has diverged from this replica"
-                            );
+                            anyhow::bail!("Server's task history has diverged from this replica");
                         }
                     }
                     requested_parent_version_id = Some(parent_version_id);

--- a/taskchampion/src/taskdb.rs
+++ b/taskchampion/src/taskdb.rs
@@ -1,7 +1,6 @@
 use crate::errors::Error;
 use crate::server::{AddVersionResult, GetVersionResult, Server};
 use crate::storage::{Operation, Storage, StorageTxn, TaskMap};
-use failure::{format_err, Fallible};
 use log::{info, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -34,7 +33,7 @@ impl TaskDB {
     /// Apply an operation to the TaskDB.  Aside from synchronization operations, this is the only way
     /// to modify the TaskDB.  In cases where an operation does not make sense, this function will do
     /// nothing and return an error (but leave the TaskDB in a consistent state).
-    pub fn apply(&mut self, op: Operation) -> Fallible<()> {
+    pub fn apply(&mut self, op: Operation) -> anyhow::Result<()> {
         // TODO: differentiate error types here?
         let mut txn = self.storage.txn()?;
         if let err @ Err(_) = TaskDB::apply_op(txn.as_mut(), &op) {
@@ -45,7 +44,7 @@ impl TaskDB {
         Ok(())
     }
 
-    fn apply_op(txn: &mut dyn StorageTxn, op: &Operation) -> Fallible<()> {
+    fn apply_op(txn: &mut dyn StorageTxn, op: &Operation) -> anyhow::Result<()> {
         match op {
             Operation::Create { uuid } => {
                 // insert if the task does not already exist
@@ -81,25 +80,25 @@ impl TaskDB {
     }
 
     /// Get all tasks.
-    pub fn all_tasks(&mut self) -> Fallible<Vec<(Uuid, TaskMap)>> {
+    pub fn all_tasks(&mut self) -> anyhow::Result<Vec<(Uuid, TaskMap)>> {
         let mut txn = self.storage.txn()?;
         txn.all_tasks()
     }
 
     /// Get the UUIDs of all tasks
-    pub fn all_task_uuids(&mut self) -> Fallible<Vec<Uuid>> {
+    pub fn all_task_uuids(&mut self) -> anyhow::Result<Vec<Uuid>> {
         let mut txn = self.storage.txn()?;
         txn.all_task_uuids()
     }
 
     /// Get the working set
-    pub fn working_set(&mut self) -> Fallible<Vec<Option<Uuid>>> {
+    pub fn working_set(&mut self) -> anyhow::Result<Vec<Option<Uuid>>> {
         let mut txn = self.storage.txn()?;
         txn.get_working_set()
     }
 
     /// Get a single task, by uuid.
-    pub fn get_task(&mut self, uuid: Uuid) -> Fallible<Option<TaskMap>> {
+    pub fn get_task(&mut self, uuid: Uuid) -> anyhow::Result<Option<TaskMap>> {
         let mut txn = self.storage.txn()?;
         txn.get_task(uuid)
     }
@@ -108,7 +107,7 @@ impl TaskDB {
     /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
     /// are not already in the working set but should be.  The rebuild occurs in a single
     /// trasnsaction against the storage backend.
-    pub fn rebuild_working_set<F>(&mut self, in_working_set: F, renumber: bool) -> Fallible<()>
+    pub fn rebuild_working_set<F>(&mut self, in_working_set: F, renumber: bool) -> anyhow::Result<()>
     where
         F: Fn(&TaskMap) -> bool,
     {
@@ -169,7 +168,7 @@ impl TaskDB {
 
     /// Add the given uuid to the working set and return its index; if it is already in the working
     /// set, its index is returned.  This does *not* renumber any existing tasks.
-    pub fn add_to_working_set(&mut self, uuid: Uuid) -> Fallible<usize> {
+    pub fn add_to_working_set(&mut self, uuid: Uuid) -> anyhow::Result<usize> {
         let mut txn = self.storage.txn()?;
         // search for an existing entry for this task..
         for (i, elt) in txn.get_working_set()?.iter().enumerate() {
@@ -185,7 +184,7 @@ impl TaskDB {
     }
 
     /// Sync to the given server, pulling remote changes and pushing local changes.
-    pub fn sync(&mut self, server: &mut Box<dyn Server>) -> Fallible<()> {
+    pub fn sync(&mut self, server: &mut Box<dyn Server>) -> anyhow::Result<()> {
         let mut txn = self.storage.txn()?;
 
         // retry synchronizing until the server accepts our version (this allows for races between
@@ -247,9 +246,9 @@ impl TaskDB {
                     );
                     if let Some(requested) = requested_parent_version_id {
                         if parent_version_id == requested {
-                            return Err(format_err!(
+                            anyhow::bail!(
                                 "Server's task history has diverged from this replica"
-                            ));
+                            );
                         }
                     }
                     requested_parent_version_id = Some(parent_version_id);
@@ -261,7 +260,7 @@ impl TaskDB {
         Ok(())
     }
 
-    fn apply_version(txn: &mut dyn StorageTxn, mut version: Version) -> Fallible<()> {
+    fn apply_version(txn: &mut dyn StorageTxn, mut version: Version) -> anyhow::Result<()> {
         // The situation here is that the server has already applied all server operations, and we
         // have already applied all local operations, so states have diverged by several
         // operations.  We need to figure out what operations to apply locally and on the server in
@@ -502,16 +501,16 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_working_set_renumber() -> Fallible<()> {
+    fn rebuild_working_set_renumber() -> anyhow::Result<()> {
         rebuild_working_set(true)
     }
 
     #[test]
-    fn rebuild_working_set_no_renumber() -> Fallible<()> {
+    fn rebuild_working_set_no_renumber() -> anyhow::Result<()> {
         rebuild_working_set(false)
     }
 
-    fn rebuild_working_set(renumber: bool) -> Fallible<()> {
+    fn rebuild_working_set(renumber: bool) -> anyhow::Result<()> {
         let mut db = TaskDB::new_inmemory();
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());


### PR DESCRIPTION
As per #148 - pretty much drop-in replacement so just a bunch of search-and-replace

I've sided on leaving anyhow fully-qualified, e.g `-> anyhow::Result<()>` etc instead of `use anyhow::Result; ... -> Result` - with the exception of `taskchampion/src/storage/mod.rs` where there it cluttered up the trait definition.

Haven't looked into using `thiserror` more extensively to give more informative errors from the core library