### PR TITLE
use the correct 'package-ecosystem' config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "rust"
+  - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
This should get dependabot working again.  Somewhere in the GitHub UI, there's a place where it reports errors from dependabot, and that showed that the correct word is "cargo" and not "rust".  I can't find that UI again, though!

Refs #165.