### PR TITLE
fix some clippy stuff

### DIFF
--- a/cli/src/argparse/mod.rs
+++ b/cli/src/argparse/mod.rs
@@ -1,3 +1,8 @@
+// Nested functions that always return Ok(..) are used as callbacks in a context where a Result is
+// expected, so the unnecessary_wraps clippy lint is not useful here.
+
+#![allow(clippy::unnecessary_wraps)]
+
 /*!
 
 This module is responsible for parsing command lines (`Arglist`, an alias for `&[&str]`) into `Command` instances.

--- a/cli/src/invocation/mod.rs
+++ b/cli/src/invocation/mod.rs
@@ -132,7 +132,7 @@ fn get_server(settings: &Config) -> anyhow::Result<Box<dyn Server>> {
         log::debug!("Using local sync-server at `{:?}`", server_dir);
         ServerConfig::Local { server_dir }
     };
-    Ok(config.into_server()?)
+    config.into_server()
 }
 
 /// Get a WriteColor implementation based on whether the output is a tty.

--- a/cli/src/invocation/mod.rs
+++ b/cli/src/invocation/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn invoke(command: Command, settings: Config) -> anyhow::Result<()> {
     log::debug!("command: {:?}", command);
     log::debug!("settings: {:?}", settings);
 
-    let mut w = get_writer()?;
+    let mut w = get_writer();
 
     // This function examines the command and breaks out the necessary bits to call one of the
     // `execute` functions in a submodule of `cmd`.
@@ -136,10 +136,10 @@ fn get_server(settings: &Config) -> anyhow::Result<Box<dyn Server>> {
 }
 
 /// Get a WriteColor implementation based on whether the output is a tty.
-fn get_writer() -> anyhow::Result<StandardStream> {
-    Ok(StandardStream::stdout(if atty::is(atty::Stream::Stdout) {
+fn get_writer() -> StandardStream {
+    StandardStream::stdout(if atty::is(atty::Stream::Stdout) {
         ColorChoice::Auto
     } else {
         ColorChoice::Never
-    }))
+    })
 }

--- a/sync-server/src/main.rs
+++ b/sync-server/src/main.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use crate::storage::{KVStorage, Storage};
+use crate::storage::{KvStorage, Storage};
 use actix_web::{get, middleware::Logger, web, App, HttpServer, Responder, Scope};
 use api::{api_scope, ServerState};
 use clap::Arg;
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let data_dir = matches.value_of("data-dir").unwrap();
     let port = matches.value_of("port").unwrap();
 
-    let server_box: Box<dyn Storage> = Box::new(KVStorage::new(data_dir)?);
+    let server_box: Box<dyn Storage> = Box::new(KvStorage::new(data_dir)?);
     let server_state = ServerState::new(server_box);
 
     log::warn!("Serving on port {}", port);

--- a/sync-server/src/storage/mod.rs
+++ b/sync-server/src/storage/mod.rs
@@ -7,7 +7,7 @@ mod inmemory;
 pub(crate) use inmemory::InMemoryStorage;
 
 mod kv;
-pub(crate) use self::kv::KVStorage;
+pub(crate) use self::kv::KvStorage;
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub(crate) struct Client {

--- a/taskchampion/src/errors.rs
+++ b/taskchampion/src/errors.rs
@@ -2,5 +2,5 @@ use thiserror::Error;
 #[derive(Debug, Error, Eq, PartialEq, Clone)]
 pub enum Error {
     #[error("Task Database Error: {}", _0)]
-    DBError(String),
+    DbError(String),
 }

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -2,7 +2,7 @@ use crate::errors::Error;
 use crate::server::Server;
 use crate::storage::{Operation, Storage, TaskMap};
 use crate::task::{Status, Task};
-use crate::taskdb::TaskDB;
+use crate::taskdb::TaskDb;
 use crate::workingset::WorkingSet;
 use chrono::Utc;
 use log::trace;
@@ -24,13 +24,13 @@ use uuid::Uuid;
 /// pending tasks are automatically added to the working set, and the working set is "renumbered"
 /// during the garbage-collection process.
 pub struct Replica {
-    taskdb: TaskDB,
+    taskdb: TaskDb,
 }
 
 impl Replica {
     pub fn new(storage: Box<dyn Storage>) -> Replica {
         Replica {
-            taskdb: TaskDB::new(storage),
+            taskdb: TaskDb::new(storage),
         }
     }
 
@@ -112,7 +112,7 @@ impl Replica {
         // check that it already exists; this is a convenience check, as the task may already exist
         // when this Create operation is finally sync'd with operations from other replicas
         if self.taskdb.get_task(uuid)?.is_none() {
-            return Err(Error::DBError(format!("Task {} does not exist", uuid)).into());
+            return Err(Error::DbError(format!("Task {} does not exist", uuid)).into());
         }
         self.taskdb.apply(Operation::Delete { uuid })?;
         trace!("task {} deleted", uuid);

--- a/taskchampion/src/storage/config.rs
+++ b/taskchampion/src/storage/config.rs
@@ -1,4 +1,4 @@
-use super::{InMemoryStorage, KVStorage, Storage};
+use super::{InMemoryStorage, KvStorage, Storage};
 use std::path::PathBuf;
 
 /// The configuration required for a replica's storage.
@@ -15,7 +15,7 @@ pub enum StorageConfig {
 impl StorageConfig {
     pub fn into_storage(self) -> anyhow::Result<Box<dyn Storage>> {
         Ok(match self {
-            StorageConfig::OnDisk { taskdb_dir } => Box::new(KVStorage::new(taskdb_dir)?),
+            StorageConfig::OnDisk { taskdb_dir } => Box::new(KvStorage::new(taskdb_dir)?),
             StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
         })
     }

--- a/taskchampion/src/storage/kv.rs
+++ b/taskchampion/src/storage/kv.rs
@@ -5,8 +5,8 @@ use kv::{Bucket, Config, Error, Integer, Serde, Store, ValueBuf};
 use std::path::Path;
 use uuid::Uuid;
 
-/// KVStorage is an on-disk storage backend which uses LMDB via the `kv` crate.
-pub struct KVStorage<'t> {
+/// KvStorage is an on-disk storage backend which uses LMDB via the `kv` crate.
+pub struct KvStorage<'t> {
     store: Store,
     tasks_bucket: Bucket<'t, Key, ValueBuf<Msgpack<TaskMap>>>,
     numbers_bucket: Bucket<'t, Integer, ValueBuf<Msgpack<u64>>>,
@@ -19,8 +19,8 @@ const BASE_VERSION: u64 = 1;
 const NEXT_OPERATION: u64 = 2;
 const NEXT_WORKING_SET_INDEX: u64 = 3;
 
-impl<'t> KVStorage<'t> {
-    pub fn new<P: AsRef<Path>>(directory: P) -> anyhow::Result<KVStorage<'t>> {
+impl<'t> KvStorage<'t> {
+    pub fn new<P: AsRef<Path>>(directory: P) -> anyhow::Result<KvStorage<'t>> {
         let mut config = Config::default(directory);
         config.bucket("tasks", None);
         config.bucket("numbers", None);
@@ -48,7 +48,7 @@ impl<'t> KVStorage<'t> {
         let working_set_bucket =
             store.int_bucket::<ValueBuf<Msgpack<Uuid>>>(Some("working_set"))?;
 
-        Ok(KVStorage {
+        Ok(KvStorage {
             store,
             tasks_bucket,
             numbers_bucket,
@@ -59,7 +59,7 @@ impl<'t> KVStorage<'t> {
     }
 }
 
-impl<'t> Storage for KVStorage<'t> {
+impl<'t> Storage for KvStorage<'t> {
     fn txn<'a>(&'a mut self) -> anyhow::Result<Box<dyn StorageTxn + 'a>> {
         Ok(Box::new(Txn {
             storage: self,
@@ -69,7 +69,7 @@ impl<'t> Storage for KVStorage<'t> {
 }
 
 struct Txn<'t> {
-    storage: &'t KVStorage<'t>,
+    storage: &'t KvStorage<'t>,
     txn: Option<kv::Txn<'t>>,
 }
 
@@ -359,7 +359,7 @@ mod test {
     #[test]
     fn test_create() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -377,7 +377,7 @@ mod test {
     #[test]
     fn test_create_exists() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -395,7 +395,7 @@ mod test {
     #[test]
     fn test_get_missing() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -408,7 +408,7 @@ mod test {
     #[test]
     fn test_set_task() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -429,7 +429,7 @@ mod test {
     #[test]
     fn test_delete_task_missing() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -441,7 +441,7 @@ mod test {
     #[test]
     fn test_delete_task_exists() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -458,7 +458,7 @@ mod test {
     #[test]
     fn test_all_tasks_empty() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         {
             let mut txn = storage.txn()?;
             let tasks = txn.all_tasks()?;
@@ -470,7 +470,7 @@ mod test {
     #[test]
     fn test_all_tasks_and_uuids() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         {
@@ -524,7 +524,7 @@ mod test {
     #[test]
     fn test_base_version_default() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         {
             let mut txn = storage.txn()?;
             assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
@@ -535,7 +535,7 @@ mod test {
     #[test]
     fn test_base_version_setting() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let u = Uuid::new_v4();
         {
             let mut txn = storage.txn()?;
@@ -552,7 +552,7 @@ mod test {
     #[test]
     fn test_operations() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let uuid3 = Uuid::new_v4();
@@ -616,7 +616,7 @@ mod test {
     #[test]
     fn get_working_set_empty() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
 
         {
             let mut txn = storage.txn()?;
@@ -630,7 +630,7 @@ mod test {
     #[test]
     fn add_to_working_set() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
 
@@ -653,7 +653,7 @@ mod test {
     #[test]
     fn clear_working_set() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new("test")?;
-        let mut storage = KVStorage::new(&tmp_dir.path())?;
+        let mut storage = KvStorage::new(&tmp_dir.path())?;
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
 

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -14,7 +14,7 @@ mod inmemory;
 mod kv;
 mod operation;
 
-pub use self::kv::KVStorage;
+pub use self::kv::KvStorage;
 pub use config::StorageConfig;
 pub use inmemory::InMemoryStorage;
 
@@ -83,7 +83,7 @@ pub trait StorageTxn {
     fn operations(&mut self) -> Result<Vec<Operation>>;
 
     /// Add an operation to the end of the list of operations in the storage.  Note that this
-    /// merely *stores* the operation; it is up to the TaskDB to apply it.
+    /// merely *stores* the operation; it is up to the TaskDb to apply it.
     fn add_operation(&mut self, op: Operation) -> Result<()>;
 
     /// Replace the current list of operations with a new list.

--- a/taskchampion/src/storage/operation.rs
+++ b/taskchampion/src/storage/operation.rs
@@ -126,7 +126,7 @@ impl Operation {
 mod test {
     use super::*;
     use crate::storage::InMemoryStorage;
-    use crate::taskdb::TaskDB;
+    use crate::taskdb::TaskDb;
     use chrono::{Duration, Utc};
     use proptest::prelude::*;
 
@@ -145,7 +145,7 @@ mod test {
 
         // check that the two operation sequences have the same effect, enforcing the invariant of
         // the transform function.
-        let mut db1 = TaskDB::new_inmemory();
+        let mut db1 = TaskDb::new_inmemory();
         if let Some(ref o) = setup {
             db1.apply(o.clone()).unwrap();
         }
@@ -154,7 +154,7 @@ mod test {
             db1.apply(o).unwrap();
         }
 
-        let mut db2 = TaskDB::new_inmemory();
+        let mut db2 = TaskDb::new_inmemory();
         if let Some(ref o) = setup {
             db2.apply(o.clone()).unwrap();
         }
@@ -307,8 +307,8 @@ mod test {
         fn transform_invariant_holds(o1 in operation_strategy(), o2 in operation_strategy()) {
             let (o1p, o2p) = Operation::transform(o1.clone(), o2.clone());
 
-            let mut db1 = TaskDB::new(Box::new(InMemoryStorage::new()));
-            let mut db2 = TaskDB::new(Box::new(InMemoryStorage::new()));
+            let mut db1 = TaskDb::new(Box::new(InMemoryStorage::new()));
+            let mut db2 = TaskDb::new(Box::new(InMemoryStorage::new()));
 
             // Ensure that any expected tasks already exist
             if let Operation::Update{ ref uuid, .. } = o1 {


### PR DESCRIPTION
Unnecessary wraps are fixed in one place and ignored in another (where they're required for a callback).

Capitalization fixed (note that this is an API-breaking change for KVStorage, but we're getting rid of that in favor of SQLite anyway)